### PR TITLE
Added localized path separators and replaced a unix-style newline with a 

### DIFF
--- a/aspen/gauntlet.py
+++ b/aspen/gauntlet.py
@@ -71,7 +71,7 @@ def virtual_paths(request):
     starting with '%' then only the 'first' is used.
 
     """
-    if '/%' in request.fs[len(request.root):]:  # disallow direct access
+    if os.sep + '%' in request.fs[len(request.root):]:  # disallow direct access
         raise Response(404)
     if not exists(request.fs):
         matched = request.root

--- a/aspen/tests/__init__.py
+++ b/aspen/tests/__init__.py
@@ -60,7 +60,7 @@ class StubRequest:
     def from_fs(cls, fs):
         """Takes a path under ./fsfix using / as the path separator.
         """
-        fs = os.sep.join(fs.split('/'))
+        fs = os.sep.join(fs.split(os.sep))
         request = Request.from_wsgi(StubWSGIRequest(fs))
         website = Configurable.from_argv(['fsfix'])
         website.copy_configuration_to(request)

--- a/aspen/tests/test_gauntlet.py
+++ b/aspen/tests/test_gauntlet.py
@@ -274,7 +274,7 @@ def test_virtual_path_docs_2():
 
 def test_virtual_path_docs_3():
     mk( ('%name/index.html', "^L\nGreetings, {{ request.path['name'] }}!")
-      , ('%name/%cheese.txt', "^L\r\n{{ request.path['name'].title() }} likes {{ request.path['cheese'] }} cheese.")
+      , ('%name/%cheese.txt', "^L\n{{ request.path['name'].title() }} likes {{ request.path['cheese'] }} cheese.")
        )
     response = handle('/chad/cheddar.txt')
     expected = "Chad likes cheddar cheese."


### PR DESCRIPTION
Added localized path separators and replaced a unix-style newline with a Python-styled one in a test. All tests now pass.
