### PR TITLE
python 2.6 compatability

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -6,7 +6,7 @@ dev: env
 	./env/bin/pip install -e ./
 
 env:
-	python2.7 ./vendor/virtualenv-1.6.4.py \
+	python ./vendor/virtualenv-1.6.4.py \
 		--distribute \
 		--unzip-setuptools \
 		--prompt="[aspen] " \

--- a/aspen/http/request.py
+++ b/aspen/http/request.py
@@ -312,8 +312,8 @@ class Line(unicode):
 # Request -> Method
 # -----------------
 
-STANDARD_METHODS = {"OPTIONS", "GET", "HEAD", "POST", "PUT", "DELETE", "TRACE",
-                    "CONNECT"}
+STANDARD_METHODS = set(["OPTIONS", "GET", "HEAD", "POST", "PUT", "DELETE", "TRACE",
+                    "CONNECT"])
 
 SEPARATORS = ("(", ")", "<", ">", "@", ",", ";", ":", "\\", '"', "/", "[", "]",
               "?", "=", "{", "}", " ", "\t")

--- a/aspen/utils.py
+++ b/aspen/utils.py
@@ -27,7 +27,8 @@ def unicode_dammit(s, encoding="UTF-8"):
     """
     if not isinstance(s, str):
         raise TypeError("You gave me something besides a str.")
-    return s.decode(encoding, errors='repr')
+    errors = 'repr'
+    return s.decode(encoding, errors)
 
 def ascii_dammit(s):
     """Given a bytestring, return a bytestring.

--- a/tests/test_utils.py
+++ b/tests/test_utils.py
@@ -10,7 +10,8 @@ def test_garbage_is_garbage():
     assert_raises(UnicodeDecodeError, lambda s: s.decode('utf8'), GARBAGE)
 
 def test_repr_error_strategy_works():
-    actual = "\xef\xf9".decode('utf8', errors='repr')
+    errors = 'repr'
+    actual = "\xef\xf9".decode('utf8', errors)
     assert actual == r"\xef\xf9", actual
 
 def test_unicode_dammit_works():


### PR DESCRIPTION
- {} syntax for sets is 2.7+
  - keyword args for str.decode() is 2.7+
