### PR TITLE
Fixes issue #98, applies correct version from egg metadata

### DIFF
--- a/aspen/__init__.py
+++ b/aspen/__init__.py
@@ -1,4 +1,5 @@
 import sys
+import pkg_resources
 
 try:                # Python >= 2.6
     from collections import Callable
@@ -15,8 +16,8 @@ from aspen.logging import log, log_dammit
 # Shut up, PyFlakes. I know I'm addicted to you.
 Response, json, is_callable, log, log_dammit
 
-
-__version__ = "~~VERSION~~"
+dist = pkg_resources.get_distribution('aspen')
+__version__ = dist.version
 WINDOWS = sys.platform[:3] == 'win'
 NETWORK_ENGINES = ['cheroot', 'cherrypy', 'diesel', 'eventlet', 'gevent',
                    'pants', 'rocket', 'tornado', 'twisted']


### PR DESCRIPTION
Please review, I'm not 100% sure this is the right way to do this.

I don't like the fact that "aspen" is hardcoded in `aspen/__init__.py`, either, as it would need to be changed if the project were forked and the name changed.
