### PR TITLE
Changed timestamp on THE_PAST to allow aspen to start in Windows.

### DIFF
--- a/aspen/website.py
+++ b/aspen/website.py
@@ -12,7 +12,7 @@ from aspen.configuration import Configurable
 from aspen.utils import to_rfc822, utc
 
 
-THE_PAST = to_rfc822(datetime.datetime(1955, 11, 05, tzinfo=utc))
+THE_PAST = to_rfc822(datetime.datetime(1970, 1, 1, tzinfo=utc))
 
 
 class Website(Configurable):


### PR DESCRIPTION
Aspen fails to start on Windows because of the definition of THE_PAST in website.py.  The issue stems from the system-dependence of time.mktime, which will throw an OverflowError if a date is not supported by the underlying system.  The date used in aspen causes the error on Windows.  I changed it to the beginning of the current epoch, which seems to be supported on Windows.  Let me know if I'm misunderstanding anything about this variable.
