### PR TITLE
Fix Tornado's template path resolver for absolute Windows paths.

### DIFF
--- a/aspen/renderers/tornado.py
+++ b/aspen/renderers/tornado.py
@@ -1,6 +1,7 @@
 from __future__ import absolute_import
 from aspen import renderers
 from tornado.template import Loader, Template
+import os
 
 
 class Renderer(renderers.Renderer):
@@ -22,5 +23,25 @@ class Factory(renderers.Factory):
         if bases_dir is None:
             loader = None
         else:
-            loader = Loader(bases_dir)
+            loader = LoaderShim(bases_dir)
         return loader
+
+
+class LoaderShim(Loader):
+    """
+    The Tornado loader doesn't properly detect absolute Windows paths when
+    resolving a template's path. This shim adds portable absolute path
+    detection, falling back to the original Loader for relative paths.
+    """
+
+    def resolve_path(self, name, parent_path=None):
+        # This is the inverse of the test Tornado's Loader.resolve_path() does
+        # on a template's name and its parent's name. Tornado only tests for
+        # absolute paths by looking for '/', which fails on Windows. If it
+        # detects an absolute path it returns the name unmodified, so we defer
+        # to the Tornado implementation if the path isn't absolute.
+        if not parent_path or parent_path.startswith("<") or \
+                os.path.isabs(parent_path) or os.path.isabs(name):
+            return name
+
+        return super(LoaderShim, self).resolve_path(name, parent_path)

--- a/tests/test_rendering.py
+++ b/tests/test_rendering.py
@@ -1,7 +1,9 @@
 from aspen.configuration import Configurable
 from aspen.renderers.tornado import Factory as TornadoFactory
 from aspen.testing import assert_raises, attach_teardown, fix, FSFIX, mk
+from aspen.testing.fsfix import convert_path
 from tornado.template import ParseError
+import os
 
 
 def test_that_a_renderer_factory_is_instantiable():
@@ -108,6 +110,15 @@ website.renderer_factories['excited-about-cheese'] = CheeseFactory(website)
     render = make_renderer("", "I like cheese!")  # test specline elsewhere
     actual = render({})
     assert actual == "I like CHEESE!!!!!!!", actual
+
+
+def test_tornado_loader_shim_resolves_path_from_absolute_nested_parent_path():
+    mk(("base.html", "Resolved."), "www")
+    make_renderer = tornado_factory_factory(["--project_root", FSFIX])
+    path = os.path.abspath(os.path.join(FSFIX, convert_path("www/index.html")))
+    render = make_renderer(path, "{% extends base.html %}")
+    actual = render({})
+    assert actual == "Resolved.", actual
 
 
 attach_teardown(globals())


### PR DESCRIPTION
Ues a shim to patch tornado.template.Loader to use os.path.isabs() to
portably detect absolute paths. Fixes an issue where the path to
extended templates can't be resolved from a nested template that was
itself loaded with an absolute path. Includes a test.
