### PR TITLE
Fix a confusing example code in docstring

### DIFF
--- a/aspen/testing/client.py
+++ b/aspen/testing/client.py
@@ -60,7 +60,7 @@ class TestClient(object):
     Example usage in a test::
 
         def test_api_handles_posts():
-            client = TestClient()
+            client = TestClient(website)
 
             # We need to get ourselves a token!
             response = client.get('/')


### PR DESCRIPTION
It might be confusing, because `TestClient`’s constructor actually takes an argument, but the example code doesn’t imply that.
