### PR TITLE
Add module entry point; allows entry with python -m aspen.server

### DIFF
--- a/aspen/server.py
+++ b/aspen/server.py
@@ -143,3 +143,6 @@ def main(argv=None):
                 time.sleep(1)
         except KeyboardInterrupt:
             raise SystemExit
+
+if __name__ == '__main__':
+    main()


### PR DESCRIPTION
This request is a re-implementation of #220 without the weird socket_io stuff (which appears to be present due to a spurious .hgsubstate in my hg-git clone of the repo).
