### PR TITLE
Remove now-redundant (due to pytest) ', actual' args to assert

### DIFF
--- a/tests/test_configuration.py
+++ b/tests/test_configuration.py
@@ -37,21 +37,21 @@ def test_everything_defaults_to_empty_string():
     expected = ( DEFAULT, DEFAULT, DEFAULT, DEFAULT, DEFAULT, DEFAULT, DEFAULT
                , DEFAULT, DEFAULT, DEFAULT, DEFAULT, DEFAULT, DEFAULT, DEFAULT
                 )
-    assert actual == expected, actual
+    assert actual == expected
 
 def test_logging_threshold_goes_to_one():
     o = OptionParser()
     opts, args = o.parse_args(['-l1'])
     actual = opts.logging_threshold
     expected = '1'
-    assert actual == expected, actual
+    assert actual == expected
 
 def test_logging_threshold_goes_to_eleven():
     o = OptionParser()
     opts, args = o.parse_args(['--logging_threshold=11'])
     actual = opts.logging_threshold
     expected = '11'
-    assert actual == expected, actual
+    assert actual == expected
 
 
 def test_configuration_scripts_can_take_one():
@@ -59,21 +59,21 @@ def test_configuration_scripts_can_take_one():
     opts, args = o.parse_args(['--configuration_scripts=startup.py'])
     actual = opts.configuration_scripts
     expected = 'startup.py'
-    assert actual == expected, actual
+    assert actual == expected
 
 def test_configuration_scripts_can_take_two_doesnt_do_anything_special():
     o = OptionParser()
     opts, args = o.parse_args(['--configuration_scripts=startup.py,uncle.py'])
     actual = opts.configuration_scripts
     expected = 'startup.py,uncle.py'
-    assert actual == expected, actual
+    assert actual == expected
 
 def test_configuration_scripts_really_doesnt_do_anything_special():
     o = OptionParser()
     opts, args = o.parse_args(['--configuration_scripts=Cheese is lovely.'])
     actual = opts.configuration_scripts
     expected = 'Cheese is lovely.'
-    assert actual == expected, actual
+    assert actual == expected
 
 def test_configuration_scripts_arent_confused_by_io_errors():
     CONFIG = "open('this file should not exist')\n"
@@ -88,7 +88,7 @@ def test_www_root_defaults_to_cwd():
     c.configure([])
     expected = os.path.realpath(os.getcwd())
     actual = c.www_root
-    assert actual == expected, actual
+    assert actual == expected
 
 def test_ConfigurationError_raised_if_no_cwd():
     mk()
@@ -106,7 +106,7 @@ def test_ConfigurationError_NOT_raised_if_no_cwd_but_do_have__www_root():
     c.configure(['--www_root', foo])
     expected = foo
     actual = c.www_root
-    assert actual == expected, actual
+    assert actual == expected
 
 def test_configurable_sees_root_option():
     mk()
@@ -114,19 +114,19 @@ def test_configurable_sees_root_option():
     c.configure(['--www_root', FSFIX])
     expected = os.getcwd()
     actual = c.www_root
-    assert actual == expected, actual
+    assert actual == expected
 
 def test_address_can_be_localhost():
     expected = (('127.0.0.1', 8000), 2)
     actual = parse.network_address(u'localhost:8000')
-    assert actual == expected, actual
+    assert actual == expected
 
 def test_configuration_scripts_works_at_all():
     o = OptionParser()
     opts, args = o.parse_args(['--configuration_scripts', "foo"])
     expected = "foo"
     actual = opts.configuration_scripts
-    assert actual == expected, actual
+    assert actual == expected
 
 def test_configuration_script_can_set_renderer_default():
     CONFIG = """
@@ -147,7 +147,7 @@ Greetings, {name}!
     response = w.handle_safely(request)
     actual = response.body.strip()
     expected = 'Greetings, program!'
-    assert actual == expected, actual
+    assert actual == expected
 
 def test_configuration_script_ignores_blank_indexfilenames():
     w = Website(['--indices', 'index.html,, ,default.html'])
@@ -160,7 +160,7 @@ def test_configuration_script_ignores_blank_indexfilenames():
 
 def test_parse_charset_good():
     actual = parse.charset(u'UTF-8')
-    assert actual == 'UTF-8', actual
+    assert actual == 'UTF-8'
 
 def test_parse_charset_bad():
     assert_raises(ValueError, parse.charset, u'')
@@ -193,32 +193,32 @@ def test_parse_yes_no_other_is_ValueError():
 
 def test_parse_list_handles_one():
     actual = parse.list_(u'foo')
-    assert actual == (False, ['foo']), actual
+    assert actual == (False, ['foo'])
 
 def test_parse_list_handles_two():
     actual = parse.list_(u'foo,bar')
-    assert actual == (False, ['foo', 'bar']), actual
+    assert actual == (False, ['foo', 'bar'])
 
 def test_parse_list_handles_spaces():
     actual = parse.list_(u' foo ,   bar ')
-    assert actual == (False, ['foo', 'bar']), actual
+    assert actual == (False, ['foo', 'bar'])
 
 def test_parse_list_handles_some_spaces():
     actual = parse.list_(u'foo,   bar, baz , buz ')
-    assert actual == (False, ['foo', 'bar', 'baz', 'buz']), actual
+    assert actual == (False, ['foo', 'bar', 'baz', 'buz'])
 
 def test_parse_list_uniquifies():
     actual = parse.list_(u'foo,foo,bar')
-    assert actual == (False, ['foo', 'bar']), actual
+    assert actual == (False, ['foo', 'bar'])
 
 def test_parse_list_extends():
     actual = parse.list_(u'+foo')
-    assert actual == (True, ['foo']), actual
+    assert actual == (True, ['foo'])
 
 
 def test_parse_renderer_good():
     actual = parse.renderer(u'stdlib_percent')
-    assert actual == u'stdlib_percent', actual
+    assert actual == u'stdlib_percent'
 
 def test_parse_renderer_bad():
     assert_raises(ValueError, parse.renderer, u'floober')
@@ -226,7 +226,7 @@ def test_parse_renderer_bad():
 
 def test_parse_network_engine_good():
     actual = parse.network_engine(u'cheroot')
-    assert actual == 'cheroot', actual
+    assert actual == 'cheroot'
 
 def test_parse_network_engine_bad():
     assert_raises(ValueError, parse.network_engine, u'floober')
@@ -234,7 +234,7 @@ def test_parse_network_engine_bad():
 
 def test_parse_network_address_unix_socket():
     actual = parse.network_address(u"/foo/bar")
-    assert actual == ("/foo/bar", socket.AF_UNIX), actual
+    assert actual == ("/foo/bar", socket.AF_UNIX)
 
 def test_parse_network_address_unix_socket_fails_on_windows():
     oldval = aspen.WINDOWS
@@ -246,18 +246,18 @@ def test_parse_network_address_unix_socket_fails_on_windows():
 
 def test_parse_network_address_notices_ipv6():
     actual = parse.network_address(u"2607:f0d0:1002:51::4")
-    assert actual == (u"2607:f0d0:1002:51::4", socket.AF_INET6), actual
+    assert actual == (u"2607:f0d0:1002:51::4", socket.AF_INET6)
 
 def test_parse_network_address_sees_one_colon_as_ipv4():
     actual = parse.network_address(u"192.168.1.1:8080")
-    assert actual == ((u"192.168.1.1", 8080), socket.AF_INET), actual
+    assert actual == ((u"192.168.1.1", 8080), socket.AF_INET)
 
 def test_parse_network_address_need_colon_for_ipv4():
     assert_raises(ValueError, parse.network_address, u"192.168.1.1 8080")
 
 def test_parse_network_address_defaults_to_inaddr_any():
     actual = parse.network_address(u':8080')
-    assert actual == ((u'0.0.0.0', 8080), socket.AF_INET), actual
+    assert actual == ((u'0.0.0.0', 8080), socket.AF_INET)
 
 def test_parse_network_address_with_bad_address():
     assert_raises(ValueError, parse.network_address, u'0 0 0 0:8080')
@@ -267,9 +267,9 @@ def test_parse_network_address_with_bad_port():
 
 def test_parse_network_address_with_port_too_low():
     actual = assert_raises(ValueError, parse.network_address, u':-1').args[0]
-    assert actual == "invalid port (out of range)", actual
+    assert actual == "invalid port (out of range)"
 
 def test_parse_network_address_with_port_too_high():
     actual = assert_raises(ValueError, parse.network_address, u':65536').args[0]
-    assert actual == "invalid port (out of range)", actual
+    assert actual == "invalid port (out of range)"
 

--- a/tests/test_dispatcher.py
+++ b/tests/test_dispatcher.py
@@ -15,12 +15,12 @@ from aspen.testing import teardown_function, fix, mk
 
 def assert_raises_404(func, *args):
     response = assert_raises(Response, func, *args)
-    assert response.code == 404, "Got " + str(response.code) + " instead of 404"
+    assert response.code == 404
     return response
 
 def assert_raises_302(func, *args):
     response = assert_raises(Response, func, *args)
-    assert response.code == 302, "Got " + str(response.code) + " instead of 302"
+    assert response.code == 302
     return response
 
 def check(path, *a):
@@ -38,7 +38,7 @@ def test_index_is_found():
     mk(('index.html', "Greetings, program!"))
     expected = fix('index.html')
     actual = check('/').fs
-    assert actual == expected, actual
+    assert actual == expected
 
 def test_negotiated_index_is_found():
     mk(( 'index'
@@ -50,7 +50,7 @@ Greetings, program!
 """))
     expected = fix('index')
     actual = check('/').fs
-    assert actual == expected, actual
+    assert actual == expected
 
 def test_alternate_index_is_not_found():
     mk(('default.html', "Greetings, program!"))
@@ -62,7 +62,7 @@ def test_alternate_index_is_found():
        )
     expected = fix('default.html')
     actual = check('/').fs
-    assert actual == expected, actual
+    assert actual == expected
 
 def test_configure_aspen_py_setting_override_works_too():
     mk( ('.aspen/configure-aspen.py', 'website.indices = ["default.html"]')
@@ -78,7 +78,7 @@ def test_configure_aspen_py_setting_takes_first():
        )
     expected = fix('index.html')
     actual = check('/').fs
-    assert actual == expected, actual
+    assert actual == expected
 
 def test_configure_aspen_py_setting_takes_second_if_first_is_missing():
     mk( ( '.aspen/configure-aspen.py'
@@ -87,7 +87,7 @@ def test_configure_aspen_py_setting_takes_second_if_first_is_missing():
        )
     expected = fix('default.html')
     actual = check('/').fs
-    assert actual == expected, actual
+    assert actual == expected
 
 def test_configure_aspen_py_setting_strips_commas():
     mk( ( '.aspen/configure-aspen.py'
@@ -96,7 +96,7 @@ def test_configure_aspen_py_setting_strips_commas():
        )
     expected = fix('default.html')
     actual = check('/').fs
-    assert actual == expected, actual
+    assert actual == expected
 
 def test_redirect_indices_to_slash():
     mk( ( '.aspen/configure-aspen.py'
@@ -123,7 +123,7 @@ def test_dont_redirect_second_index_if_first():
     # second shouldn't
     expected = fix('default.html')
     actual = check('/default.html').fs
-    assert actual == expected, actual
+    assert actual == expected
 
 
 # Negotiated Fall-through
@@ -133,25 +133,25 @@ def test_indirect_negotiation_can_passthrough_renderered():
     mk(('foo.html', "Greetings, program!"))
     expected = fix('foo.html')
     actual = check('foo.html').fs
-    assert actual == expected, actual
+    assert actual == expected
 
 def test_indirect_negotiation_can_passthrough_negotiated():
     mk(('foo', "Greetings, program!"))
     expected = fix('foo')
     actual = check('foo').fs
-    assert actual == expected, actual
+    assert actual == expected
 
 def test_indirect_negotiation_modifies_one_dot():
     mk(('foo', "Greetings, program!"))
     expected = fix('foo')
     actual = check('foo.html').fs
-    assert actual == expected, actual
+    assert actual == expected
 
 def test_indirect_negotiation_skips_two_dots():
     mk(('foo.bar', "Greetings, program!"))
     expected = fix('foo.bar')
     actual = check('foo.bar.html').fs
-    assert actual == expected, actual + " isn't " + expected
+    assert actual == expected
 
 def test_indirect_negotiation_prefers_rendered():
     mk( ('foo.html', "Greetings, program!")
@@ -159,7 +159,7 @@ def test_indirect_negotiation_prefers_rendered():
        )
     expected = fix('foo.html')
     actual = check('foo.html').fs
-    assert actual == expected, actual
+    assert actual == expected
 
 def test_indirect_negotiation_really_prefers_rendered():
     mk( ('foo.html', "Greetings, program!")
@@ -167,7 +167,7 @@ def test_indirect_negotiation_really_prefers_rendered():
        )
     expected = fix('foo.html')
     actual = check('foo.html').fs
-    assert actual == expected, actual
+    assert actual == expected
 
 def test_indirect_negotiation_really_prefers_rendered_2():
     mk( ('foo.html', "Greetings, program!")
@@ -175,7 +175,7 @@ def test_indirect_negotiation_really_prefers_rendered_2():
        )
     expected = fix('foo.html')
     actual = check('foo.html').fs
-    assert actual == expected, actual
+    assert actual == expected
 
 def test_indirect_negotation_doesnt_do_dirs():
     mk(('foo/bar.html', "Greetings, program!"))
@@ -189,7 +189,7 @@ def test_virtual_path_can_passthrough():
     mk(('foo.html', "Greetings, program!"))
     expected = fix('foo.html')
     actual = check('foo.html').fs
-    assert actual == expected, actual
+    assert actual == expected
 
 def test_unfound_virtual_path_passes_through():
     mk(('%bar/foo.html', "Greetings, program!"))
@@ -199,25 +199,25 @@ def test_virtual_path_is_virtual():
     mk(('%bar/foo.html', "Greetings, program!"))
     expected = fix('%bar/foo.html')
     actual = check('/blah/foo.html').fs
-    assert actual == expected, actual
+    assert actual == expected
 
 def test_virtual_path_sets_request_path():
     mk(('%bar/foo.html', "Greetings, program!"))
     expected = {'bar': [u'blah']}
     actual = check('/blah/foo.html').line.uri.path
-    assert actual == expected, actual
+    assert actual == expected
 
 def test_virtual_path_sets_unicode_request_path():
     mk(('%bar/foo.html', "Greetings, program!"))
     expected = {'bar': [u'\u2603']}
     actual = check('/%E2%98%83/foo.html').line.uri.path
-    assert actual == expected, actual
+    assert actual == expected
 
 def test_virtual_path_typecasts_to_int():
     mk(('%year.int/foo.html', "Greetings, program!"))
     expected = {'year': [1999]}
     actual = check('/1999/foo.html').line.uri.path
-    assert actual == expected, actual
+    assert actual == expected
 
 def test_virtual_path_raises_on_bad_typecast():
     mk(('%year.int/foo.html', "Greetings, program!"))
@@ -241,25 +241,25 @@ def test_virtual_path_matches_the_first():
        )
     expected = fix('%first/foo.html')
     actual = check('/1999/foo.html').fs
-    assert actual == expected, actual
+    assert actual == expected
 
 def test_virtual_path_directory():
     mk(('%first/index.html', "Greetings, program!"))
     expected = fix('%first/index.html')
     actual = check('/foo/').fs
-    assert actual == expected, actual + " != " + expected
+    assert actual == expected
 
 def test_virtual_path_file():
     mk(('foo/%bar.html.spt', "Greetings, program!"))
     expected = fix('foo/%bar.html.spt')
     actual = check('/foo/blah.html').fs
-    assert actual == expected, actual
+    assert actual == expected
 
 def test_virtual_path_file_only_last_part():
     mk(('foo/%bar.html.spt', "Greetings, program!"))
     expected = fix('foo/%bar.html.spt')
     actual = check('/foo/blah/baz.html').fs
-    assert actual == expected, actual
+    assert actual == expected
 
 def test_virtual_path_file_only_last_part____no_really():
     mk(('foo/%bar.html', "Greetings, program!"))
@@ -269,19 +269,19 @@ def test_virtual_path_file_key_val_set():
     mk(('foo/%bar.html.spt', "Greetings, program!"))
     expected = {'bar': [u'blah']}
     actual = check('/foo/blah.html').line.uri.path
-    assert actual == expected, actual
+    assert actual == expected
 
 def test_virtual_path_file_key_val_not_cast():
     mk(('foo/%bar.html.spt', "Greetings, program!"))
     expected = {'bar': [u'537']}
     actual = check('/foo/537.html').line.uri.path
-    assert actual == expected, actual
+    assert actual == expected
 
 def test_virtual_path_file_key_val_cast():
     mk(('foo/%bar.int.html.spt', "Greetings, program!"))
     expected = {'bar': [537]}
     actual = check('/foo/537.html').line.uri.path
-    assert actual == expected, repr(actual) + " isn't " + repr(expected)
+    assert actual == expected
 
 def test_virtual_path_file_not_dir():
     mk( ('%foo/bar.html', "Greetings from bar!")
@@ -289,7 +289,7 @@ def test_virtual_path_file_not_dir():
        )
     expected = fix('%baz.html.spt')
     actual = check('/bal.html').fs
-    assert actual == expected, actual
+    assert actual == expected
 
 
 # negotiated *and* virtual paths
@@ -301,19 +301,19 @@ def test_virtual_path__and_indirect_neg_file_not_dir():
        )
     expected = fix('%baz.spt')
     actual = check('/bal.html').fs
-    assert actual == expected, actual
+    assert actual == expected
 
 def test_virtual_path_and_indirect_neg_noext():
     mk( ('%foo/bar', "Greetings program!"))
     actual = check('/greet/bar').fs
     expected = fix('%foo/bar')
-    assert actual == expected, actual
+    assert actual == expected
 
 def test_virtual_path_and_indirect_neg_ext():
     mk( ('%foo/bar', "Greetings program!"))
     actual = check('/greet/bar.html').fs
     expected = fix('%foo/bar')
-    assert actual == expected, actual
+    assert actual == expected
 
 
 # trailing slash
@@ -327,40 +327,40 @@ def test_trailing_slash_passes_dirs_with_slash_through():
     mk(('foo/index.html', "Greetings, program!"))
     expected = fix('/foo/index.html')
     actual = check('/foo/').fs
-    assert actual == expected, actual
+    assert actual == expected
 
 def test_dispatcher_passes_through_virtual_dir_with_trailing_slash():
     mk(('%foo/index.html', "Greetings, program!"))
     expected = fix('/%foo/index.html')
     actual = check('/foo/').fs
-    assert actual == expected, actual + " isn't " + expected
+    assert actual == expected
 
 def test_dispatcher_redirects_dir_without_trailing_slash():
     mk('foo')
     response = assert_raises(Response, check, '/foo')
     expected = (302, '/foo/')
     actual = (response.code, response.headers['Location'])
-    assert actual == expected, actual
+    assert actual == expected
 
 def test_dispatcher_redirects_virtual_dir_without_trailing_slash():
     mk('%foo')
     response = assert_raises(Response, check, '/foo')
     expected = (302, '/foo/')
     actual = (response.code, response.headers['Location'])
-    assert actual == expected, actual
+    assert actual == expected
 
 def test_trailing_on_virtual_paths_missing():
     mk('%foo/%bar/%baz')
     response = assert_raises(Response, check, '/foo/bar/baz')
     expected = '/foo/bar/baz/'
     actual = response.headers['Location']
-    assert actual == expected, actual
+    assert actual == expected
 
 def test_trailing_on_virtual_paths():
     mk(('%foo/%bar/%baz/index.html', "Greetings program!"))
     expected = fix('/%foo/%bar/%baz/index.html')
     actual = check('/foo/bar/baz/').fs
-    assert actual == expected, actual + " isn't " + expected
+    assert actual == expected
 
 
 # path part params
@@ -370,37 +370,37 @@ def test_path_part_with_params_works():
     mk(('foo/index.html', "Greetings program!"))
     expected = fix('/foo/index.html')
     actual = check('/foo;a=1/').fs
-    assert actual == expected, actual + " isn't " + expected
+    assert actual == expected
 
 def test_path_part_params_vpath():
     mk(('%bar/index.html', "Greetings program!"))
     expected = fix('/%bar/index.html')
     actual = check('/foo;a=1;b=;a=2;b=3/').fs
-    assert actual == expected, actual + " isn't " + expected
+    assert actual == expected
 
 def test_path_part_params_static_file():
     mk(('/foo/bar.html', "Greetings program!"))
     expected = fix('/foo/bar.html')
     actual = check('/foo/bar.html;a=1;b=;a=2;b=3').fs
-    assert actual == expected, actual + " isn't " + expected
+    assert actual == expected
 
 def test_path_part_params_simplate():
     mk(('/foo/bar.html.spt', "Greetings program!"))
     expected = fix('/foo/bar.html.spt')
     actual = check('/foo/bar.html;a=1;b=;a=2;b=3').fs
-    assert actual == expected, actual + " isn't " + expected
+    assert actual == expected
 
 def test_path_part_params_negotiated_simplate():
     mk(('/foo/bar.spt', "Greetings program!"))
     expected = fix('/foo/bar.spt')
     actual = check('/foo/bar.html;a=1;b=;a=2;b=3').fs
-    assert actual == expected, actual + " isn't " + expected
+    assert actual == expected
 
 def test_path_part_params_greedy_simplate():
     mk(('/foo/%bar.spt', "Greetings program!"))
     expected = fix('/foo/%bar.spt')
     actual = check('/foo/baz/buz;a=1;b=;a=2;b=3/blam.html').fs
-    assert actual == expected, actual + " isn't " + expected
+    assert actual == expected
 
 
 # Docs
@@ -413,14 +413,14 @@ def test_virtual_path_docs_1():
     expected = "Greetings, aspen!"
     response = handle('/aspen/')
     actual = response.body
-    assert actual == expected, repr(actual) + " from " + repr(response)
+    assert actual == expected
 
 def test_virtual_path_docs_2():
     mk(('%name/index.html.spt', GREETINGS_NAME_SPT))
     expected = "Greetings, python!"
     response = handle('/python/')
     actual = response.body
-    assert actual == expected, actual
+    assert actual == expected
 
 NAME_LIKES_CHEESE_SPT = "name = path['name'].title()\ncheese = path['cheese']\n[---------]\n%(name)s likes %(cheese)s cheese."
 
@@ -431,7 +431,7 @@ def test_virtual_path_docs_3():
     response = handle('/chad/cheddar.txt')
     expected = "Chad likes cheddar cheese."
     actual = response.body
-    assert actual == expected, actual
+    assert actual == expected
 
 def test_virtual_path_docs_4():
     mk( ( '%name/index.html.spt', GREETINGS_NAME_SPT),
@@ -440,7 +440,7 @@ def test_virtual_path_docs_4():
     response = handle('/chad/cheddar.txt/')
     expected = 404
     actual = response.code
-    assert actual == expected, actual
+    assert actual == expected
 
 PARTY_LIKE_YEAR_SPT = "year = path['year']\n[----------]\nTonight we're going to party like it's %(year)s!"
 
@@ -452,14 +452,14 @@ def test_virtual_path_docs_5():
     response = handle('/1999/')
     expected = "Greetings, 1999!"
     actual = response.body
-    assert actual == expected, actual
+    assert actual == expected
 
 def test_virtual_path_docs_6():
     mk( ( '%year.int/index.html.spt', PARTY_LIKE_YEAR_SPT))
     response = handle('/1999/')
     expected = "Tonight we're going to party like it's 1999!"
     actual = response.body
-    assert actual == expected, actual
+    assert actual == expected
 
 
 # intercept_socket
@@ -473,13 +473,13 @@ def test_intercept_socket_intercepts_handshake():
     request = Request(uri="/foo.sock/1")
     actual = dispatcher.extract_socket_info(request.line.uri.path.decoded)
     expected = ('/foo.sock', '1')
-    assert actual == expected, actual
+    assert actual == expected
 
 def test_intercept_socket_intercepts_transported():
     request = Request(uri="/foo.sock/1/websocket/46327hfjew3?foo=bar")
     actual = dispatcher.extract_socket_info(request.line.uri.path.decoded)
     expected = ('/foo.sock', '1/websocket/46327hfjew3')
-    assert actual == expected, actual
+    assert actual == expected
 
 
 # mongs
@@ -490,7 +490,7 @@ def test_virtual_path_parts_can_be_empty():
     mk(('foo/%bar/index.html.spt', "Greetings, program!"))
     expected = {u'bar': [u'']}
     actual = check('/foo//').line.uri.path
-    assert actual == expected, actual
+    assert actual == expected
 
 def test_file_matches_in_face_of_dir():
     mk( ('%page/index.html.spt', 'Nothing to see here.')
@@ -498,7 +498,7 @@ def test_file_matches_in_face_of_dir():
        )
     expected = {'value': [u'baz']}
     actual = check('/baz.txt').line.uri.path
-    assert actual == expected, actual
+    assert actual == expected
 
 def test_file_matches_extension():
     mk( ('%value.json.spt', '{"Greetings,": "program!"}')
@@ -506,7 +506,7 @@ def test_file_matches_extension():
        )
     expected = "%value.json.spt"
     actual = os.path.basename(check('/baz.json').fs)
-    assert actual == expected, actual
+    assert actual == expected
 
 def test_file_matches_other_extension():
     mk( ('%value.json.spt', '{"Greetings,": "program!"}')
@@ -514,7 +514,7 @@ def test_file_matches_other_extension():
        )
     expected = "%value.txt.spt"
     actual = os.path.basename(check('/baz.txt').fs)
-    assert actual == expected, actual
+    assert actual == expected
 
 def test_virtual_file_with_no_extension_works():
     mk(('%value.spt', '{"Greetings,": "program!"}'))
@@ -534,7 +534,7 @@ def test_file_with_no_extension_matches():
        )
     expected = {'value': [u'baz']}
     actual = check('/baz').line.uri.path
-    assert actual == expected, actual
+    assert actual == expected
 
 def test_aspen_favicon_doesnt_get_clobbered_by_virtual_path():
     mk('%value.spt')
@@ -542,13 +542,13 @@ def test_aspen_favicon_doesnt_get_clobbered_by_virtual_path():
     dispatcher.dispatch(request)
     expected = {}
     actual = request.line.uri.path
-    assert actual == expected, actual
+    assert actual == expected
 
 def test_robots_txt_also_shouldnt_be_redirected():
     mk('%value.spt')
     request = StubRequest.from_fs('/robots.txt')
     err = assert_raises(Response, dispatcher.dispatch, request)
     actual = err.code
-    assert actual == 404, actual
+    assert actual == 404
 
 

--- a/tests/test_hooks.py
+++ b/tests/test_hooks.py
@@ -9,14 +9,14 @@ from aspen.testing import teardown_function
 
 def test_hooks_is_barely_instantiable():
     actual = Hooks().__class__
-    assert actual == Hooks, actual
+    assert actual == Hooks
 
 def test_hooks_can_Be_run():
     hooks = Hooks()
     thing = object()
     hooks.yeah_hook = [lambda thing: thing]
     actual = hooks.run('yeah_hook', thing)
-    assert actual is thing, actual
+    assert actual is thing
 
 
 

--- a/tests/test_json_resource.py
+++ b/tests/test_json_resource.py
@@ -17,7 +17,7 @@ def test_json_basically_works():
     actual = check( "[---]\nresponse.body = {'Greetings': 'program!'}"
                   , filename="foo.json.spt"
                    )
-    assert actual == expected, actual
+    assert actual == expected
 
 def test_json_cant_have_more_than_one_page_break():
     assert_raises(SyntaxError, check, "[---]\n[---]\n", filename="foo.json.spt")
@@ -28,7 +28,7 @@ def test_json_defaults_to_application_json_for_static_json():
                   , filename="foo.json"
                   , body=False
                    ).headers['Content-Type']
-    assert actual == expected, actual
+    assert actual == expected
 
 def test_json_defaults_to_application_json_for_dynamic_json():
     expected = 'application/json'
@@ -36,7 +36,7 @@ def test_json_defaults_to_application_json_for_dynamic_json():
                   , filename="foo.json.spt"
                   , body=False
                    ).headers['Content-Type']
-    assert actual == expected, actual
+    assert actual == expected
 
 def test_json_content_type_is_configurable_for_static_json():
     configure_aspen_py = 'website.media_type_json = "floober/blah"'
@@ -46,7 +46,7 @@ def test_json_content_type_is_configurable_for_static_json():
                   , body=False
                   , configure_aspen_py=configure_aspen_py
                    ).headers['Content-Type']
-    assert actual == expected, actual
+    assert actual == expected
 
 def test_json_content_type_is_configurable_from_the_command_line():
     expected = 'floober/blah'
@@ -55,7 +55,7 @@ def test_json_content_type_is_configurable_from_the_command_line():
                   , body=False
                   , argv=['--media_type_json=floober/blah']
                    ).headers['Content-Type']
-    assert actual == expected, actual
+    assert actual == expected
 
 def test_json_content_type_is_configurable_for_dynamic_json():
     configure_aspen_py = 'website.media_type_json = "floober/blah"'
@@ -65,7 +65,7 @@ def test_json_content_type_is_configurable_for_dynamic_json():
                   , body=False
                   , configure_aspen_py=configure_aspen_py
                    ).headers['Content-Type']
-    assert actual == expected, actual
+    assert actual == expected
 
 def test_json_content_type_is_per_file_configurable():
     expected = 'floober/blah'
@@ -73,7 +73,7 @@ def test_json_content_type_is_per_file_configurable():
                   , filename="foo.json.spt"
                   , body=False
                    ).headers['Content-Type']
-    assert actual == expected, actual
+    assert actual == expected
 
 def test_json_handles_unicode():
     expected = b'''{
@@ -82,7 +82,7 @@ def test_json_handles_unicode():
     actual = check( "[---]\nresponse.body = {'Greetings': unichr(181)}"
                   , filename="foo.json.spt"
                    )
-    assert actual == expected, actual
+    assert actual == expected
 
 def test_json_doesnt_handle_non_ascii_bytestrings():
     assert_raises( UnicodeDecodeError
@@ -100,7 +100,7 @@ def test_json_handles_time():
                   + "response.body = {'seen': datetime.time(19, 30)}"
                   , filename="foo.json.spt"
                    )
-    assert actual == expected, actual
+    assert actual == expected
 
 def test_json_handles_date():
     expected = '''{
@@ -111,7 +111,7 @@ def test_json_handles_date():
                   + "response.body = {'created': datetime.date(2011, 5, 9)}"
                   , filename="foo.json.spt"
                    )
-    assert actual == expected, actual
+    assert actual == expected
 
 def test_json_handles_datetime():
     expected = '''{
@@ -123,7 +123,7 @@ def test_json_handles_datetime():
                   + "                : datetime.datetime(2011, 5, 9, 0, 0)}"
                   , filename="foo.json.spt"
                    )
-    assert actual == expected, actual
+    assert actual == expected
 
 def test_json_handles_complex():
     expected = '''{
@@ -138,7 +138,7 @@ def test_json_handles_complex():
     # The json module puts trailing spaces after commas, but simplejson
     # does not. Normalize the actual input to work around that.
     actual = '\n'.join([line.rstrip() for line in actual.split('\n')])
-    assert actual == expected, actual
+    assert actual == expected
 
 def test_json_raises_TypeError_on_unknown_types():
     assert_raises( TypeError
@@ -152,7 +152,7 @@ def test_aspen_json_load_loads():
     fp.write('{"cheese": "puffs"}')
     fp.seek(0)
     actual = json.load(fp)
-    assert actual == {'cheese': 'puffs'}, actual
+    assert actual == {'cheese': 'puffs'}
 
 def test_aspen_json_dump_dumps():
     fp = StringIO.StringIO()
@@ -161,17 +161,17 @@ def test_aspen_json_dump_dumps():
     actual = fp.read()
     assert actual == '''{
     "cheese": "puffs"
-}''', actual
+}'''
 
 def test_aspen_json_loads_loads():
     actual = json.loads('{"cheese": "puffs"}')
-    assert actual == {'cheese': 'puffs'}, actual
+    assert actual == {'cheese': 'puffs'}
 
 def test_aspen_json_dumps_dumps():
     actual = json.dumps({'cheese': 'puffs'})
     assert actual == '''{
     "cheese": "puffs"
-}''', actual
+}'''
 
 
 # Teardown

--- a/tests/test_logging.py
+++ b/tests/test_logging.py
@@ -40,17 +40,17 @@ def capture(*a, **kw):
 
 def test_log_logs_something():
     actual = capture("oh heck", level=4)
-    assert actual == ["oh heck"], actual
+    assert actual == ["oh heck"]
 
 def test_log_logs_several_somethings():
     actual = capture("oh\nheck", u"what?", {}, [], None, level=4)
-    assert actual == ["oh", "heck", "what?", "{}", "[]", "None"], actual
+    assert actual == ["oh", "heck", "what?", "{}", "[]", "None"]
 
 def test_log_dammit_works():
     actual = capture("yes\nrly", {}, [], None, threshold=1, func=log_dammit)
-    assert actual == ["yes", "rly", "{}", "[]", "None"], actual
+    assert actual == ["yes", "rly", "{}", "[]", "None"]
 
 def test_logging_unicode_works():
     actual = capture("oh \u2614 heck", level=4)
-    assert actual == ["oh \u2614 heck"], actual
+    assert actual == ["oh \u2614 heck"]
 

--- a/tests/test_mappings.py
+++ b/tests/test_mappings.py
@@ -20,7 +20,7 @@ def test_mapping_subscript_assignment_clobbers():
     m['foo'] = 'buz'
     expected = ['buz']
     actual = dict.__getitem__(m, 'foo')
-    assert actual == expected, actual
+    assert actual == expected
 
 def test_mapping_subscript_access_returns_last():
     m = Mapping()
@@ -29,7 +29,7 @@ def test_mapping_subscript_access_returns_last():
     m['foo'] = 'buz'
     expected = 'buz'
     actual = m['foo']
-    assert actual == expected, actual
+    assert actual == expected
 
 def test_mapping_get_returns_last():
     m = Mapping()
@@ -38,19 +38,19 @@ def test_mapping_get_returns_last():
     m['foo'] = 'buz'
     expected = 'buz'
     actual = m.get('foo')
-    assert actual == expected, actual
+    assert actual == expected
 
 def test_mapping_get_returns_default():
     m = Mapping()
     expected = 'cheese'
     actual = m.get('foo', 'cheese')
-    assert actual == expected, actual
+    assert actual == expected
 
 def test_mapping_get_default_default_is_None():
     m = Mapping()
     expected = None
     actual = m.get('foo')
-    assert actual is expected, actual
+    assert actual is expected
 
 def test_mapping_all_returns_list_of_all_values():
     m = Mapping()
@@ -59,7 +59,7 @@ def test_mapping_all_returns_list_of_all_values():
     m.add('foo', 'buz')
     expected = ['bar', 'baz', 'buz']
     actual = m.all('foo')
-    assert actual == expected, actual
+    assert actual == expected
 
 def test_mapping_ones_returns_list_of_last_values():
     m = Mapping()
@@ -74,7 +74,7 @@ def test_mapping_ones_returns_list_of_last_values():
     m['baz'] = 9
     expected = [2, 5, 9]
     actual = m.ones('foo', 'bar', 'baz')
-    assert actual == expected, actual
+    assert actual == expected
 
 def test_mapping_deleting_a_key_removes_it_entirely():
     m = Mapping()
@@ -82,7 +82,7 @@ def test_mapping_deleting_a_key_removes_it_entirely():
     m['foo'] = 2
     m['foo'] = 3
     del m['foo']
-    assert 'foo' not in m, m.keys()
+    assert 'foo' not in m
 
 def test_accessing_missing_key_raises_Response():
     m = Mapping()
@@ -99,7 +99,7 @@ def test_mapping_pop_returns_the_last_item():
     m.add('foo', 3)
     expected = 3
     actual = m.pop('foo')
-    assert actual == expected, actual
+    assert actual == expected
 
 def test_mapping_pop_leaves_the_rest():
     m = Mapping()
@@ -109,7 +109,7 @@ def test_mapping_pop_leaves_the_rest():
     m.pop('foo')
     expected = [1, 1]
     actual = m.all('foo')
-    assert actual == expected, actual
+    assert actual == expected
 
 def test_mapping_pop_removes_the_item_if_that_was_the_last_value():
     m = Mapping()
@@ -117,7 +117,7 @@ def test_mapping_pop_removes_the_item_if_that_was_the_last_value():
     m.pop('foo')
     expected = []
     actual = m.keys()
-    assert actual == expected, actual
+    assert actual == expected
 
 def test_mapping_popall_returns_a_list():
     m = Mapping()
@@ -126,7 +126,7 @@ def test_mapping_popall_returns_a_list():
     m.add('foo', 3)
     expected = [1, 1, 3]
     actual = m.popall('foo')
-    assert actual == expected, actual
+    assert actual == expected
 
 def test_mapping_popall_removes_the_item():
     m = Mapping()
@@ -134,7 +134,7 @@ def test_mapping_popall_removes_the_item():
     m['foo'] = 1
     m['foo'] = 3
     m.popall('foo')
-    assert 'foo' not in m, m.keys()
+    assert 'foo' not in m
 
 
 def test_default_mapping_is_case_insensitive():
@@ -145,7 +145,7 @@ def test_default_mapping_is_case_insensitive():
     m['FOO'] = 1
     expected = [1]
     actual = m.all('foo')
-    assert actual == expected, actual
+    assert actual == expected
 
 def test_case_insensitive_mapping_access_is_case_insensitive():
     m = CaseInsensitiveMapping()
@@ -155,7 +155,7 @@ def test_case_insensitive_mapping_access_is_case_insensitive():
     m['FOO'] = 11
     expected = 11
     actual = m['foo']
-    assert actual == expected, actual
+    assert actual == expected
 
 def test_case_insensitive_mapping_get_is_case_insensitive():
     m = CaseInsensitiveMapping()
@@ -165,7 +165,7 @@ def test_case_insensitive_mapping_get_is_case_insensitive():
     m['FOO'] = 1
     expected = 1
     actual = m.get('foo')
-    assert actual == expected, actual
+    assert actual == expected
 
 def test_case_insensitive_mapping_all_is_case_insensitive():
     m = CaseInsensitiveMapping()
@@ -175,7 +175,7 @@ def test_case_insensitive_mapping_all_is_case_insensitive():
     m.add('FOO', 1)
     expected = [1, 1, 1, 1]
     actual = m.all('foo')
-    assert actual == expected, actual
+    assert actual == expected
 
 def test_case_insensitive_mapping_pop_is_case_insensitive():
     m = CaseInsensitiveMapping()
@@ -185,7 +185,7 @@ def test_case_insensitive_mapping_pop_is_case_insensitive():
     m['FOO'] = 11
     expected = 11
     actual = m.pop('foo')
-    assert actual == expected, actual
+    assert actual == expected
 
 def test_case_insensitive_mapping_popall_is_case_insensitive():
     m = CaseInsensitiveMapping()
@@ -195,7 +195,7 @@ def test_case_insensitive_mapping_popall_is_case_insensitive():
     m.add('FOO', 11)
     expected = [1, 99, 1, 11]
     actual = m.popall('foo')
-    assert actual == expected, actual
+    assert actual == expected
 
 def test_case_insensitive_mapping_ones_is_case_insensitive():
     m = CaseInsensitiveMapping()
@@ -207,26 +207,26 @@ def test_case_insensitive_mapping_ones_is_case_insensitive():
     m.add('BAR', 200)
     expected = [12, 200]
     actual = m.ones('Foo', 'Bar')
-    assert actual == expected, actual
+    assert actual == expected
 
 
 def est_headers_are_case_insensitive():
     headers = BaseHeaders('Foo: bar')
     expected = 'bar'
     actual = headers.one('foo')
-    assert actual == expected, actual
+    assert actual == expected
 
 def est_querystring_basically_works():
     querystring = Querystring('Foo=bar')
     expected = 'bar'
     actual = querystring.one('Foo', default='missing')
-    assert actual == expected, actual
+    assert actual == expected
 
 def est_querystring_is_case_sensitive():
     querystring = Querystring('Foo=bar')
     expected = 'missing'
     actual = querystring.one('foo', default='missing')
-    assert actual == expected, actual
+    assert actual == expected
 
 
 

--- a/tests/test_negotiated_resource.py
+++ b/tests/test_negotiated_resource.py
@@ -30,7 +30,7 @@ def test_negotiated_resource_is_instantiable():
     media_type = ''
     mtime = 0
     actual = NegotiatedResource(website, fs, raw, media_type, mtime).__class__
-    assert actual is NegotiatedResource, actual
+    assert actual is NegotiatedResource
 
 
 # compile_page
@@ -41,12 +41,12 @@ def test_compile_page_chokes_on_truly_empty_page():
 def test_compile_page_compiles_empty_page():
     page = get().compile_page(Page('', 'text/html'))
     actual = page[0]({}), page[1]
-    assert actual == ('', 'text/html'), actual
+    assert actual == ('', 'text/html')
 
 def test_compile_page_compiles_page():
     page = get().compile_page(Page('foo bar', 'text/html'))
     actual = page[0]({}), page[1]
-    assert actual == ('foo bar', 'text/html'), actual
+    assert actual == ('foo bar', 'text/html')
 
 
 # _parse_specline
@@ -54,7 +54,7 @@ def test_compile_page_compiles_page():
 def test_parse_specline_parses_specline():
     factory, media_type = get()._parse_specline('media/type via stdlib_template')
     actual = (factory.__class__, media_type)
-    assert actual == (TemplateFactory, 'media/type'), actual
+    assert actual == (TemplateFactory, 'media/type')
 
 def test_parse_specline_doesnt_require_renderer():
     factory, media_type = get()._parse_specline('media/type')
@@ -91,7 +91,7 @@ def test_parse_specline_obeys_default_by_media_type_default():
     resource.website.default_renderers_by_media_type.default_factory = lambda: 'glubber'
     err = assert_raises(ValueError, resource._parse_specline, 'media/type')
     msg = err.args[0]
-    assert msg.startswith("Unknown renderer for media/type: glubber."), msg
+    assert msg.startswith("Unknown renderer for media/type: glubber.")
 
 def test_get_renderer_factory_can_raise_syntax_error():
     resource = get()
@@ -102,7 +102,7 @@ def test_get_renderer_factory_can_raise_syntax_error():
                        , 'oo*gle'
                         )
     msg = err.args[0]
-    assert msg.startswith("Malformed renderer oo*gle. It must match"), msg
+    assert msg.startswith("Malformed renderer oo*gle. It must match")
 
 
 # get_response
@@ -127,19 +127,19 @@ def test_get_response_gets_response():
     response = Response()
     request = StubRequest.from_fs('index.spt')
     actual = get_response(request, response)
-    assert actual is response, actual
+    assert actual is response
 
 def test_get_response_is_happy_not_to_negotiate():
     mk(('index.spt', NEGOTIATED_RESOURCE))
     request = StubRequest.from_fs('index.spt')
     actual = get_response(request, Response()).body
-    assert actual == "Greetings, program!\n", actual
+    assert actual == "Greetings, program!\n"
 
 def test_get_response_sets_content_type_when_it_doesnt_negotiate():
     mk(('index.spt', NEGOTIATED_RESOURCE))
     request = StubRequest.from_fs('index.spt')
     actual = get_response(request, Response()).headers['Content-Type']
-    assert actual == "text/plain; charset=UTF-8", actual
+    assert actual == "text/plain; charset=UTF-8"
 
 def test_get_response_doesnt_reset_content_type_when_not_negotiating():
     mk(('index.spt', NEGOTIATED_RESOURCE))
@@ -147,7 +147,7 @@ def test_get_response_doesnt_reset_content_type_when_not_negotiating():
     response = Response()
     response.headers['Content-Type'] = 'never/mind'
     actual = get_response(request, response).headers['Content-Type']
-    assert actual == "never/mind", actual
+    assert actual == "never/mind"
 
 
 def test_get_response_negotiates():
@@ -155,14 +155,14 @@ def test_get_response_negotiates():
     request = StubRequest.from_fs('index.spt')
     request.headers['Accept'] = 'text/html'
     actual = get_response(request, Response()).body
-    assert actual == "<h1>Greetings, program!</h1>\n", actual
+    assert actual == "<h1>Greetings, program!</h1>\n"
 
 def test_get_response_sets_content_type_when_it_negotiates():
     mk(('index.spt', NEGOTIATED_RESOURCE))
     request = StubRequest.from_fs('index.spt')
     request.headers['Accept'] = 'text/html'
     actual = get_response(request, Response()).headers['Content-Type']
-    assert actual == "text/html; charset=UTF-8", actual
+    assert actual == "text/html; charset=UTF-8"
 
 def test_get_response_doesnt_reset_content_type_when_negotiating():
     mk(('index.spt', NEGOTIATED_RESOURCE))
@@ -174,14 +174,14 @@ def test_get_response_doesnt_reset_content_type_when_negotiating():
     response = Response()
     response.headers['Content-Type'] = 'never/mind'
     actual = get_response(request, response).headers['Content-Type']
-    assert actual == "never/mind", actual
+    assert actual == "never/mind"
 
 def test_get_response_raises_406_if_need_be():
     mk(('index.spt', NEGOTIATED_RESOURCE))
     request = StubRequest.from_fs('index.spt')
     request.headers['Accept'] = 'cheese/head'
     actual = assert_raises(Response, get_response, request, Response()).code
-    assert actual == 406, actual
+    assert actual == 406
 
 def test_get_response_406_gives_list_of_acceptable_types():
     mk(('index.spt', NEGOTIATED_RESOURCE))
@@ -189,7 +189,7 @@ def test_get_response_406_gives_list_of_acceptable_types():
     request.headers['Accept'] = 'cheese/head'
     actual = assert_raises(Response, get_response, request, Response()).body
     expected = "The following media types are available: text/plain, text/html."
-    assert actual == expected, actual
+    assert actual == expected
 
 
 OVERRIDE_SIMPLATE = """\
@@ -214,7 +214,7 @@ def test_can_override_default_renderers_by_mimetype():
     request = StubRequest.from_fs('index.spt')
     request.headers['Accept'] = 'text/plain'
     actual = get_response(request, Response()).body
-    assert actual == "glubber", actual
+    assert actual == "glubber"
 
 def test_can_override_default_renderer_entirely():
     mk(('.aspen/configure-aspen.py', OVERRIDE_SIMPLATE),
@@ -222,7 +222,7 @@ def test_can_override_default_renderer_entirely():
     request = StubRequest.from_fs('index.spt')
     request.headers['Accept'] = 'text/plain'
     actual = get_response(request, Response()).body
-    assert actual == "glubber", actual
+    assert actual == "glubber"
 
 
 # indirect
@@ -240,20 +240,20 @@ def test_indirect_negotiation_sets_media_type():
     response = handle('/foo.html')
     expected = "<h1>Greetings, program!</h1>\n"
     actual = response.body
-    assert actual == expected, actual
+    assert actual == expected
 
 def test_indirect_negotiation_sets_media_type_to_secondary():
     mk(('/foo.spt', INDIRECTLY_NEGOTIATED_RESOURCE))
     response = handle('/foo.txt')
     expected = "Greetings, program!"
     actual = response.body
-    assert actual == expected, actual
+    assert actual == expected
 
 def test_indirect_negotiation_with_unsupported_media_type_is_404():
     mk(('/foo.spt', INDIRECTLY_NEGOTIATED_RESOURCE))
     response = handle('/foo.jpg')
     actual = response.code
-    assert actual == 404, actual
+    assert actual == 404
 
 
 INDIRECTLY_NEGOTIATED_VIRTUAL_RESOURCE = """\
@@ -270,7 +270,7 @@ def test_negotiated_inside_virtual_path():
     response = handle('/program/bar.txt')
     expected = "Greetings, program!"
     actual = response.body
-    assert actual == expected, actual
+    assert actual == expected
 
 INDIRECTLY_NEGOTIATED_VIRTUAL_RESOURCE_STARTYPE = """\
 [-------]
@@ -293,14 +293,14 @@ def test_negotiated_inside_virtual_path_with_startype_partial_match():
     response = handle('/program/bar.txt')
     expected = "Greetings, program!"
     actual = response.body
-    assert actual == expected, "got " + repr(actual) + " instead of " + repr(expected)
+    assert actual == expected
 
 def test_negotiated_inside_virtual_path_with_startype_fallback():
     mk(('/%foo/bar.spt', INDIRECTLY_NEGOTIATED_VIRTUAL_RESOURCE_STARTYPE ))
     response = handle('/program/bar.jpg')
     expected = "Unknown request type, program!"
     actual = response.body.strip()
-    assert actual == expected, "got " + repr(actual) + " instead of " + repr(expected)
+    assert actual == expected
 
 
 

--- a/tests/test_request.py
+++ b/tests/test_request.py
@@ -14,13 +14,13 @@ def test_request_line_raw_works():
     request = StubRequest()
     actual = request.line.raw
     expected = u"GET / HTTP/1.1"
-    assert actual == expected, actual
+    assert actual == expected
 
 def test_raw_is_raw():
     request = Request()
     expected = b"GET / HTTP/1.1\r\nHost: localhost\r\n\r\n"
     actual = request
-    assert actual == expected, actual
+    assert actual == expected
 
 def test_blank_by_default():
     assert_raises(AttributeError, lambda: Request().version)
@@ -29,50 +29,50 @@ def test_request_line_version_defaults_to_HTTP_1_1():
     request = StubRequest()
     actual = request.line.version.info
     expected = (1, 1)
-    assert actual == expected, actual
+    assert actual == expected
 
 def test_request_line_version_raw_works():
     request = StubRequest()
     actual = request.line.version.raw
     expected = u"HTTP/1.1"
-    assert actual == expected, actual
+    assert actual == expected
 
 def test_allow_default_method_is_GET():
     request = StubRequest()
     expected = u'GET'
     actual = request.line.method
-    assert actual == expected, actual
+    assert actual == expected
 
 def test_allow_allows_allowed():
     request = StubRequest()
     expected = None
     actual = request.allow('GET')
-    assert actual is expected, actual
+    assert actual is expected
 
 def test_allow_disallows_disallowed():
     request = StubRequest()
     expected = 405
     actual = assert_raises(Response, request.allow, 'POST').code
-    assert actual == expected, actual
+    assert actual == expected
 
 def test_allow_can_handle_lowercase():
     request = StubRequest()
     expected = 405
     actual = assert_raises(Response, request.allow, 'post').code
-    assert actual == expected, actual
+    assert actual == expected
 
 def test_methods_start_with_GET():
     request = StubRequest()
     expected = "GET"
     actual = request.line.method
-    assert actual == expected, actual
+    assert actual == expected
 
 def test_methods_changing_changes():
     request = StubRequest()
     request.line.method = 'POST'
     expected = "POST"
     actual = request.line.method
-    assert actual == expected, actual
+    assert actual == expected
 
 def test_is_xhr_false():
     request = StubRequest()
@@ -93,25 +93,25 @@ def test_headers_access_gets_a_value():
     headers = BaseHeaders(b"Foo: Bar")
     expected = b"Bar"
     actual = headers['Foo']
-    assert actual == expected, actual
+    assert actual == expected
 
 def test_headers_access_gets_last_value():
     headers = BaseHeaders(b"Foo: Bar\r\nFoo: Baz")
     expected = b"Baz"
     actual = headers['Foo']
-    assert actual == expected, actual
+    assert actual == expected
 
 def test_headers_access_is_case_insensitive():
     headers = BaseHeaders(b"Foo: Bar")
     expected = b"Bar"
     actual = headers['foo']
-    assert actual == expected, actual
+    assert actual == expected
 
 def test_headers_dont_unicodify_cookie():
     headers = BaseHeaders(b"Cookie: somecookiedata")
     expected = b"somecookiedata"
     actual = headers[b'Cookie']
-    assert actual == expected, actual
+    assert actual == expected
 
 
 # kick_against_goad
@@ -124,7 +124,7 @@ def test_goad_passes_method_through():
 
     expected = (b'\xdead\xbeef', b'', b'', b'', b'', None)
     actual = kick_against_goad(environ)
-    assert actual == expected, actual
+    assert actual == expected
 
 def test_goad_makes_franken_uri():
     environ = {}
@@ -136,7 +136,7 @@ def test_goad_makes_franken_uri():
 
     expected = ('', '/cheese?foo=bar', '', '', '', '')
     actual = kick_against_goad(environ)
-    assert actual == expected, actual
+    assert actual == expected
 
 def test_goad_passes_version_through():
     environ = {}
@@ -146,7 +146,7 @@ def test_goad_passes_version_through():
 
     expected = (b'', b'', b'', b'\xdead\xbeef', b'', None)
     actual = kick_against_goad(environ)
-    assert actual == expected, actual
+    assert actual == expected
 
 def test_goad_makes_franken_headers():
     environ = {}
@@ -157,7 +157,7 @@ def test_goad_makes_franken_headers():
 
     expected = (b'', b'', b'', b'', b'FOO-BAR: baz=buz', b'')
     actual = kick_against_goad(environ)
-    assert actual == expected, actual
+    assert actual == expected
 
 def test_goad_passes_body_through():
     environ = {}
@@ -167,25 +167,25 @@ def test_goad_passes_body_through():
 
     expected = (b'', b'', b'', b'', b'', b'\xdead\xbeef')
     actual = kick_against_goad(environ)
-    assert actual == expected, actual
+    assert actual == expected
 
 
 def test_request_redirect_works_on_instance():
     request = Request()
     actual = assert_raises(Response, request.redirect, '/').code
-    assert actual == 302, actual
+    assert actual == 302
 
 def test_request_redirect_works_on_class():
     actual = assert_raises(Response, Request.redirect, '/').code
-    assert actual == 302, actual
+    assert actual == 302
 
 def test_request_redirect_code_is_settable():
     actual = assert_raises(Response, Request.redirect, '/', code=8675309).code
-    assert actual == 8675309, actual
+    assert actual == 8675309
 
 def test_request_redirect_permanent_convenience():
     actual = assert_raises(Response, Request.redirect, '/', permanent=True).code
-    assert actual == 301, actual
+    assert actual == 301
 
 
 

--- a/tests/test_request_body.py
+++ b/tests/test_request_body.py
@@ -29,20 +29,20 @@ def make_body(raw, headers=None, content_type=WWWFORM):
 def test_body_is_instantiable():
     body = make_body("cheese=yes")
     actual = body.__class__.__name__
-    assert actual == "Body", actual
+    assert actual == "Body"
 
 def test_body_is_unparsed_for_empty_content_type():
     actual = make_body("cheese=yes", headers={})
-    assert actual == {}, actual
+    assert actual == {}
 
 def test_body_gives_empty_dict_for_empty_body():
     actual = make_body("")
-    assert actual == {}, actual
+    assert actual == {}
 
 def test_body_barely_works():
     body = make_body("cheese=yes")
     actual = body['cheese']
-    assert actual == "yes", actual
+    assert actual == "yes"
 
 
 UPLOAD = """\
@@ -61,16 +61,16 @@ Content-Type: text/plain
 def test_body_barely_works_for_form_data():
     body = make_body(UPLOAD, content_type=FORMDATA)
     actual = body['files'].filename
-    assert actual == "file1.txt", actual
+    assert actual == "file1.txt"
 
 def test_simple_values_are_simple():
     body = make_body(UPLOAD, content_type=FORMDATA)
     actual = body['submit-name']
-    assert actual == "Larry", actual
+    assert actual == "Larry"
 
 def test_params_doesnt_break_www_form():
     body = make_body("statement=foo"
                     , content_type="application/x-www-form-urlencoded; charset=UTF-8; cheese=yummy"
                      )
     actual = body['statement']
-    assert actual == "foo", actual
+    assert actual == "foo"

--- a/tests/test_request_line.py
+++ b/tests/test_request_line.py
@@ -15,19 +15,19 @@ from aspen.testing import assert_raises, teardown_function
 
 def test_line_works():
     line = Line("GET", "/", "HTTP/0.9")
-    assert line == u"GET / HTTP/0.9", line
+    assert line == u"GET / HTTP/0.9"
 
 def test_line_has_method():
     line = Line("GET", "/", "HTTP/0.9")
-    assert line.method == u"GET", line.method
+    assert line.method == u"GET"
 
 def test_line_has_uri():
     line = Line("GET", "/", "HTTP/0.9")
-    assert line.uri == u"/", line.uri
+    assert line.uri == u"/"
 
 def test_line_has_version():
     line = Line("GET", "/", "HTTP/0.9")
-    assert line.version == u"HTTP/0.9", line.version
+    assert line.version == u"HTTP/0.9"
 
 def test_line_chokes_on_non_ASCII_in_uri():
     assert_raises(UnicodeDecodeError, Line, "GET", chr(128), "HTTP/1.1")
@@ -38,27 +38,27 @@ def test_line_chokes_on_non_ASCII_in_uri():
 
 def test_method_works():
     method = Method("GET")
-    assert method == u"GET", method
+    assert method == u"GET"
 
 def test_method_is_unicode_subclass():
     method = Method("GET")
-    assert issubclass(method.__class__, unicode), method.__class__
+    assert issubclass(method.__class__, unicode)
 
 def test_method_is_unicode_instance():
     method = Method("GET")
-    assert isinstance(method, unicode), method
+    assert isinstance(method, unicode)
 
 def test_method_is_basestring_instance():
     method = Method("GET")
-    assert isinstance(method, basestring), method
+    assert isinstance(method, basestring)
 
 def test_method_raw_works():
     method = Method("GET")
-    assert method.raw == "GET", method.raw
+    assert method.raw == "GET"
 
 def test_method_raw_is_bytestring():
     method = Method(b"GET")
-    assert isinstance(method.raw, str), method.raw
+    assert isinstance(method.raw, str)
 
 def test_method_cant_have_more_attributes():
     method = Method("GET")
@@ -158,7 +158,7 @@ def test_uri_works_at_all():
     uri = URI("/")
     expected = u"/"
     actual = uri
-    assert actual == expected, actual
+    assert actual == expected
 
 def test_a_nice_unicode_uri():
     uri = URI(b"http://%E2%98%84:bar@localhost:5370/+%E2%98%84.html?%E2%98%84=%E2%98%84+bar")
@@ -288,17 +288,17 @@ def test_uri_raw_is_available_on_something():
 def test_version_can_be_HTTP_0_9():
     actual = Version("HTTP/0.9")
     expected = u"HTTP/0.9"
-    assert actual == expected, actual
+    assert actual == expected
 
 def test_version_can_be_HTTP_1_0():
     actual = Version("HTTP/1.0")
     expected = u"HTTP/1.0"
-    assert actual == expected, actual
+    assert actual == expected
 
 def test_version_can_be_HTTP_1_1():
     actual = Version("HTTP/1.1")
     expected = u"HTTP/1.1"
-    assert actual == expected, actual
+    assert actual == expected
 
 def test_version_cant_be_HTTP_1_2():
     assert assert_raises(Response, Version, b"HTTP/1.2").code == 505
@@ -321,25 +321,25 @@ def test_version_major_is_int():
     version = Version("HTTP/1.0")
     expected = 1
     actual = version.major
-    assert actual == expected, actual
+    assert actual == expected
 
 def test_version_major_is_int():
     version = Version("HTTP/0.9")
     expected = 9
     actual = version.minor
-    assert actual == expected, actual
+    assert actual == expected
 
 def test_version_info_is_tuple():
     version = Version("HTTP/0.9")
     expected = (0, 9)
     actual = version.info
-    assert actual == expected, actual
+    assert actual == expected
 
 def test_version_raw_is_bytestring():
     version = Version(b"HTTP/0.9")
     expected = str
     actual = version.raw.__class__
-    assert actual is expected, actual
+    assert actual is expected
 
 
 # Path
@@ -391,19 +391,19 @@ def test_extract_path_params_with_none():
     request = Request(uri="/foo/bar")
     actual = _extract_params(request.line.uri)
     expected = (['foo', 'bar'], [{}, {}])
-    assert actual == expected, actual
+    assert actual == expected
 
 def test_extract_path_params_simple():
     request = Request(uri="/foo;a=1;b=2;c/bar;a=2;b=1")
     actual = _extract_params(request.line.uri)
     expected = (['foo', 'bar'], [{'a':['1'], 'b':['2'], 'c':['']}, {'a':['2'], 'b':['1']}])
-    assert actual == expected, actual
+    assert actual == expected
 
 def test_extract_path_params_complex():
     request = Request(uri="/foo;a=1;b=2,3;c;a=2;b=4/bar;a=2,ab;b=1")
     actual = _extract_params(request.line.uri)
     expected = (['foo', 'bar'], [{'a':['1','2'], 'b':['2,3', '4'], 'c':['']}, {'a':[ '2,ab' ], 'b':['1']}])
-    assert actual == expected, actual
+    assert actual == expected
 
 def test_path_params_api():
     request = Request(uri="/foo;a=1;b=2;b=3;c/bar;a=2,ab;b=1")

--- a/tests/test_resources.py
+++ b/tests/test_resources.py
@@ -19,7 +19,7 @@ def test_barely_working():
 
     expected = 'text/html'
     actual = response.headers['Content-Type']
-    assert actual == expected, actual
+    assert actual == expected
 
 def test_charset_static_barely_working():
     response = check( "Greetings, program!", 'index.html', False
@@ -27,7 +27,7 @@ def test_charset_static_barely_working():
                      )
     expected = 'text/html; charset=OOG'
     actual = response.headers['Content-Type']
-    assert actual == expected, actual
+    assert actual == expected
 
 def test_charset_dynamic_barely_working():
     response = check( "[---]\nGreetings, program!", 'index.html.spt', False
@@ -35,12 +35,12 @@ def test_charset_dynamic_barely_working():
                      )
     expected = 'text/html; charset=CHEESECODE'
     actual = response.headers['Content-Type']
-    assert actual == expected, actual
+    assert actual == expected
 
 def test_resource_pages_work():
     expected = "Greetings, bar!"
     actual = check("foo = 'bar'\n[--------]\nGreetings, %(foo)s!")
-    assert actual == expected, actual
+    assert actual == expected
 
 def test_resource_dunder_all_limits_vars():
     actual = assert_raises( KeyError
@@ -51,7 +51,7 @@ def test_resource_dunder_all_limits_vars():
                               "Greetings, %(foo)s!"
                              )
     # in production, KeyError is turned into a 500 by an outer wrapper
-    assert type(actual) == KeyError, actual
+    assert type(actual) == KeyError
 
 def test_path_part_params_are_available():
     mk(('/foo/index.html.spt', """
@@ -61,7 +61,7 @@ if 'b' in path.parts[0].params:
 %(a)s"""))
     expected = "3"
     actual = handle('/foo;a=1;b;a=3/').body
-    assert actual == expected, actual + " isn't " + expected
+    assert actual == expected
 
 def test_utf8():
     expected = unichr(1758).encode('utf8')
@@ -73,7 +73,7 @@ text = unichr(1758)
 [------------------]
 %(text)s
     """).strip()
-    assert actual == expected, repr(actual) + " != expected " + repr(expected)
+    assert actual == expected
 
 def test_resources_dont_leak_whitespace():
     """This aims to resolve https://github.com/whit537/aspen/issues/8.
@@ -84,7 +84,7 @@ def test_resources_dont_leak_whitespace():
         [--------------]
         %(foo)r"""))
     expected = "[1, 2, 3, 4]"
-    assert actual == expected, repr(actual)
+    assert actual == expected
 
 def test_negotiated_resource_doesnt_break():
     expected = "Greetings, bar!\n"
@@ -97,7 +97,7 @@ Greetings, %(foo)s!
 <h1>Greetings, %(foo)s!</h1>
 """
 , filename='index.spt')
-    assert actual == expected, actual
+    assert actual == expected
 
 
 # Unicode example in the /templating/ doc.
@@ -115,12 +115,12 @@ def test_content_type_is_right_in_template_doc_unicode_example():
     response = check(eg, body=False)
     expected = "text/plain; charset=latin1"
     actual = response.headers['Content-Type']
-    assert actual == expected, actual
+    assert actual == expected
 
 def test_body_is_right_in_template_doc_unicode_example():
     expected = chr(181)
     actual = check(eg).strip()
-    assert actual == expected, actual
+    assert actual == expected
 
 
 # raise Response
@@ -135,14 +135,14 @@ def test_raise_response_works():
                               "[---------]\n"
                              )
     actual = response.code
-    assert actual == expected, actual
+    assert actual == expected
 
 def test_exception_location_preserved_for_response_raised_in_page_2():
     # https://github.com/gittip/aspen-python/issues/153
     expected = ('index.html.spt', 1)
     try: check("from aspen import Response; raise Response(404)\n[---]\n")
     except Response, response: actual = response.whence_raised()
-    assert actual == expected, actual
+    assert actual == expected
 
 def test_website_is_in_context():
     expected = "It worked."
@@ -151,7 +151,7 @@ assert website.__class__.__name__ == 'Website', website
 [--------]
 [--------]
 It worked.""")
-    assert actual == expected, actual
+    assert actual == expected
 
 def test_unknown_mimetype_yields_default_mimetype():
     response = check( "Greetings, program!"
@@ -160,7 +160,7 @@ def test_unknown_mimetype_yields_default_mimetype():
                      )
     expected = "text/plain"
     actual = response.headers['Content-Type']
-    assert actual == expected, actual
+    assert actual == expected
 
 def test_templating_without_script_works():
     response = Response()
@@ -170,14 +170,14 @@ def test_templating_without_script_works():
     # StubRequest that we don't get one.
 
     actual = check("[-----] via stdlib_format\n{request.line.uri.path.raw}", response=response)
-    assert actual == expected, actual
+    assert actual == expected
 
 
 # Test offset calculation
 
 def check_offsets(raw, offsets):
     actual = [page.offset for page in split(raw)]
-    assert actual == offsets, actual
+    assert actual == offsets
 
 def test_offset_calculation_basic():
     check_offsets('\n\n\n[---]\n\n', [0, 4])

--- a/tests/test_response.py
+++ b/tests/test_response.py
@@ -15,13 +15,13 @@ def test_response_is_a_wsgi_callable():
         pass
     expected = ["Greetings, program!"]
     actual = list(response({}, start_response).body)
-    assert actual == expected, actual
+    assert actual == expected
 
 def test_response_body_can_be_bytestring():
     response = Response(body=b"Greetings, program!")
     expected = "Greetings, program!"
     actual = response.body
-    assert actual == expected, actual
+    assert actual == expected
 
 def test_response_body_as_bytestring_results_in_an_iterable():
     response = Response(body=b"Greetings, program!")
@@ -29,13 +29,13 @@ def test_response_body_as_bytestring_results_in_an_iterable():
         pass
     expected = ["Greetings, program!"]
     actual = list(response({}, start_response).body)
-    assert actual == expected, actual
+    assert actual == expected
 
 def test_response_body_can_be_iterable():
     response = Response(body=["Greetings, ", "program!"])
     expected = ["Greetings, ", "program!"]
     actual = response.body
-    assert actual == expected, actual
+    assert actual == expected
 
 def test_response_body_as_iterable_comes_through_untouched():
     response = Response(body=["Greetings, ", "program!"])
@@ -43,7 +43,7 @@ def test_response_body_as_iterable_comes_through_untouched():
         pass
     expected = ["Greetings, ", "program!"]
     actual = list(response({}, start_response).body)
-    assert actual == expected, actual
+    assert actual == expected
 
 def test_response_body_can_be_unicode():
     try:

--- a/tests/test_sockets_.py
+++ b/tests/test_sockets_.py
@@ -14,7 +14,7 @@ def test_sockets_get_nonsock_returns_None():
     request.socket = None
     expected = None
     actual = sockets.get(request)
-    assert actual is expected, actual
+    assert actual is expected
 
 def test_sockets_get_adds_channel():
     mk(('echo.sock.spt', '[---]\n'))
@@ -26,7 +26,7 @@ def test_sockets_get_adds_channel():
 
         expected = '/echo.sock'
         actual = sockets.__channels__['/echo.sock'].name
-        assert actual == expected, actual
+        assert actual == expected
     finally:
         sockets.__channels__['/echo.sock'].disconnect_all()
 
@@ -42,11 +42,11 @@ def test_channel_survives_transportation():
     try:
         expected = '/echo.sock'
         actual = sockets.__channels__['/echo.sock'].name
-        assert actual == expected, actual
+        assert actual == expected
 
         expected = transport.socket.channel
         actual = sockets.__channels__['/echo.sock']
-        assert actual is expected, actual
+        assert actual is expected
     finally:
         transport.socket.disconnect()
 

--- a/tests/test_sockets_buffer.py
+++ b/tests/test_sockets_buffer.py
@@ -9,7 +9,7 @@ def test_buffer_is_instantiable():
     mk(('echo.sock.spt', 'socket.send(socket.recv())'))
     expected = Buffer
     actual = Buffer(make_socket(), 'foo').__class__
-    assert actual is expected, actual
+    assert actual is expected
 
 def test_can_put_onto_buffer():
     mk(('echo.sock.spt', 'socket.send(socket.recv())'))
@@ -17,7 +17,7 @@ def test_can_put_onto_buffer():
     expected = [FFFD+'4'+FFFD+'1:::']
     buffer.put(Message.from_bytes('1:::'))
     actual = list(buffer.flush())
-    assert actual == expected, actual
+    assert actual == expected
 
 def test_buffer_flush_performance():
 
@@ -29,7 +29,7 @@ def test_buffer_flush_performance():
     out = list(buffer.flush())
     nbuffer = len(buffer)
     nout = len(out)
-    assert nbuffer + nout == N, (nbuffer, nout)
+    assert nbuffer + nout == N
     assert nout > 500
 
 

--- a/tests/test_sockets_channel.py
+++ b/tests/test_sockets_channel.py
@@ -11,7 +11,7 @@ from aspen.testing.fsfix import mk, teardown_function
 def test_channel_is_instantiable():
     expected = Channel
     actual = Channel('/foo.sock', ThreadedBuffer).__class__
-    assert actual is expected, actual
+    assert actual is expected
 
 def test_channel_can_have_sockets_added_to_it():
     mk(('echo.sock.spt', 'channel.send(channel.recv())'))
@@ -21,7 +21,7 @@ def test_channel_can_have_sockets_added_to_it():
 
     expected = [socket]
     actual = list(channel)
-    assert actual == expected, actual
+    assert actual == expected
 
 def test_channel_raises_AssertionError_on_double_add():
     mk(('echo.sock.spt', ''))
@@ -39,7 +39,7 @@ def test_channel_passes_send_on_to_one_socket():
 
     expected = deque([Message.from_bytes('3::/echo.sock:foo')])
     actual = socket.outgoing.queue
-    assert actual == expected, actual
+    assert actual == expected
 
 def test_channel_passes_send_on_to_four_sockets():
     mk(('echo.sock.spt', 'channel.send(channel.recv())'))
@@ -50,6 +50,6 @@ def test_channel_passes_send_on_to_four_sockets():
     for socket in sockets:
         expected = deque([Message.from_bytes('3::/echo.sock:foo')])
         actual = socket.outgoing.queue
-        assert actual == expected, actual
+        assert actual == expected
 
 

--- a/tests/test_sockets_message.py
+++ b/tests/test_sockets_message.py
@@ -10,73 +10,73 @@ from aspen.testing import assert_raises, teardown_function
 def test_message_can_be_instantiated_from_bytes():
     expected = Message
     actual = Message.from_bytes('3:::').__class__
-    assert actual is expected, actual
+    assert actual is expected
 
 def test_from_bytes_too_few_colons_raises_SyntaxError():
     exc = assert_raises(SyntaxError, Message.from_bytes, '3:')
     expected = "This message has too few colons: 3:."
     actual = exc.args[0]
-    assert actual == expected, actual
+    assert actual == expected
 
 def test_from_bytes_data_part_is_optional():
     message = Message.from_bytes('3::')
     expected = ""
     actual = message.data
-    assert actual == expected, actual
+    assert actual == expected
 
 def test_from_bytes_too_many_colons_and_the_extras_end_up_in_the_data():
     message = Message.from_bytes('3::::')
     expected = ":"
     actual = message.data
-    assert actual == expected, actual
+    assert actual == expected
 
 def test_from_bytes_non_digit_type_raises_ValueError():
     exc = assert_raises(ValueError, Message.from_bytes, 'foo:::')
     expected = "The message type is not in 0..8: foo."
     actual = exc.args[0]
-    assert actual == expected, actual
+    assert actual == expected
 
 def test_from_bytes_type_too_small_raises_ValueError():
     exc = assert_raises(ValueError, Message.from_bytes, '-1:::')
     expected = "The message type is not in 0..8: -1."
     actual = exc.args[0]
-    assert actual == expected, actual
+    assert actual == expected
 
 def test_from_bytes_type_too_big_raises_ValueError():
     exc = assert_raises(ValueError, Message.from_bytes, '9:::')
     expected = "The message type is not in 0..8: 9."
     actual = exc.args[0]
-    assert actual == expected, actual
+    assert actual == expected
 
 def test_from_bytes_type_lower_bound_instantiable():
     message = Message.from_bytes('0:::')
     expected = 0
     actual = message.type
-    assert actual == expected, actual
+    assert actual == expected
 
 def test_from_bytes_type_upper_bound_instantiable():
     message = Message.from_bytes('8:::')
     expected = 8
     actual = message.type
-    assert actual == expected, actual
+    assert actual == expected
 
 def test_id_passes_through():
     message = Message.from_bytes('3:deadbeef::')
     expected = 'deadbeef'
     actual = message.id
-    assert actual == expected, actual
+    assert actual == expected
 
 def test_endpoint_passes_through():
     message = Message.from_bytes('3:deadbeef:/cheese.sock:')
     expected = '/cheese.sock'
     actual = message.endpoint
-    assert actual == expected, actual
+    assert actual == expected
 
 def test_data_passes_through():
     message = Message.from_bytes('3:deadbeef:/cheese.sock:Greetings, program!')
     expected = 'Greetings, program!'
     actual = message.data
-    assert actual == expected, actual
+    assert actual == expected
 
 def test_json_data_decoded():
     message = Message.from_bytes('''4:deadbeef:/cheese.sock:{
@@ -84,7 +84,7 @@ def test_json_data_decoded():
 }''')
     expected = {"foo": "bar"}
     actual = message.data
-    assert actual == expected, actual
+    assert actual == expected
 
 def test_json_roundtrip():
     bytes = '''4:deadbeef:/cheese.sock:{
@@ -93,7 +93,7 @@ def test_json_roundtrip():
     message = Message.from_bytes(bytes)
     expected = bytes
     actual = str(message)
-    assert actual == expected, actual
+    assert actual == expected
 
 def test_event_data_decoded():
     message = Message.from_bytes('''5:::{
@@ -101,7 +101,7 @@ def test_event_data_decoded():
 }''')
     expected = {u'args': [], u'name': 'bar'}
     actual = message.data
-    assert actual == expected, actual
+    assert actual == expected
 
 def test_event_data_without_name_raises_ValueError():
     exc = assert_raises( ValueError
@@ -110,7 +110,7 @@ def test_event_data_without_name_raises_ValueError():
                              )
     expected = "An event message must have a 'name' key."
     actual = exc.args[0]
-    assert actual == expected, actual
+    assert actual == expected
 
 def test_event_data_without_args_raises_ValueError():
     exc = assert_raises( ValueError
@@ -119,7 +119,7 @@ def test_event_data_without_args_raises_ValueError():
                              )
     expected = "An event message must have an 'args' key."
     actual = exc.args[0]
-    assert actual == expected, actual
+    assert actual == expected
 
 def test_event_data_with_reserved_name_raises_ValueError():
     exc = assert_raises( ValueError
@@ -128,7 +128,7 @@ def test_event_data_with_reserved_name_raises_ValueError():
                         )
     expected = "That event name is reserved: connect."
     actual = exc.args[0]
-    assert actual == expected, actual
+    assert actual == expected
 
 
 

--- a/tests/test_sockets_packet.py
+++ b/tests/test_sockets_packet.py
@@ -12,17 +12,17 @@ from aspen.testing import assert_raises, teardown_function
 def test_packet_Packetable_with_unframed_bytes():
     expected = [Message.from_bytes(b'1:::')]
     actual = list(Packet(b'1:::'))
-    assert actual == expected, actual
+    assert actual == expected
 
 def test_packet_Packetable_with_framed_bytes():
     expected = [Message.from_bytes(b'1:::')]
     actual = list(Packet(FFFD + b'4' + FFFD + b'1:::'))
-    assert actual == expected, actual
+    assert actual == expected
 
 def test_packet_Packetable_with_multiple_frames():
     expected = [Message.from_bytes(x) for x in (b'0:::', b'1:::')]
     actual = list(Packet(FFFD+b'4'+FFFD+b'0:::'+FFFD+b'4'+FFFD+b'1:::'))
-    assert actual == expected, repr(actual)
+    assert actual == expected
 
 def test_packet_with_odd_frames_raises_SyntaxError():
     Packet_ = lambda s: list(Packet(s)) # assert_raises chokes on generator
@@ -34,7 +34,7 @@ def test_packet_with_odd_frames_tells_you_that():
     exc = assert_raises(SyntaxError, Packet_, packet)
     expected = b"There are an odd number of frames in this packet: %s" % packet
     actual = exc.args[0]
-    assert actual == expected, actual
+    assert actual == expected
 
 
 

--- a/tests/test_sockets_socket.py
+++ b/tests/test_sockets_socket.py
@@ -16,7 +16,7 @@ def test_socket_is_instantiable():
 
     expected = Socket
     actual = make_socket().__class__
-    assert actual is expected, actual
+    assert actual is expected
 
 def test_two_sockets_are_instantiable():
     mk(('echo.sock.spt', ''))
@@ -26,7 +26,7 @@ def test_two_sockets_are_instantiable():
 
     expected = (Socket, Socket)
     actual = (socket1.__class__, socket2.__class__)
-    assert actual == expected, actual
+    assert actual == expected
 
 def test_socket_can_shake_hands():
     mk(('echo.sock.spt', ''))
@@ -34,7 +34,7 @@ def test_socket_can_shake_hands():
     response = socket.shake_hands()
     expected = '15:10:xhr-polling'
     actual = response.body.split(':', 1)[1]
-    assert actual == expected, actual
+    assert actual == expected
 
 def test_socket_can_barely_function():
     mk(('echo.sock.spt', 'socket.send("Greetings, program!")'))
@@ -46,7 +46,7 @@ def test_socket_can_barely_function():
     actual = socket._recv()
     if actual is not None:
         actual = actual.next()
-    assert actual == expected, actual
+    assert actual == expected
 
 def test_socket_can_echo():
     mk(('echo.sock.spt', 'socket.send(socket.recv())'))
@@ -59,6 +59,6 @@ def test_socket_can_echo():
         actual = socket._recv()
         if actual is not None:
             actual = actual.next()
-        assert actual == expected, actual
+        assert actual == expected
 
 

--- a/tests/test_sockets_transport.py
+++ b/tests/test_sockets_transport.py
@@ -31,7 +31,7 @@ def test_transport_instantiable():
 
     expected = XHRPollingTransport
     actual = transport.__class__
-    assert actual is expected, actual
+    assert actual is expected
 
 def test_transport_can_minimally_respond():
     transport = make_transport()
@@ -39,7 +39,7 @@ def test_transport_can_minimally_respond():
 
     expected = Response
     actual = transport.respond(request).__class__
-    assert actual is expected, actual
+    assert actual is expected
 
 def test_transport_starts_in_state_0():
     transport = make_transport()
@@ -47,7 +47,7 @@ def test_transport_starts_in_state_0():
 
     expected = 0
     actual = transport.state
-    assert actual == expected, actual
+    assert actual == expected
 
 def test_transport_goes_to_state_1_after_first_request():
     transport = make_transport()
@@ -56,7 +56,7 @@ def test_transport_goes_to_state_1_after_first_request():
 
     expected = 1
     actual = transport.state
-    assert actual == expected, actual
+    assert actual == expected
 
 def test_transport_stays_in_state_1_after_second_request():
     transport = make_transport()
@@ -66,7 +66,7 @@ def test_transport_stays_in_state_1_after_second_request():
 
     expected = 1
     actual = transport.state
-    assert actual == expected, actual
+    assert actual == expected
 
 def test_transport_POST_gives_data_to_socket():
     transport = make_transport(state=1)
@@ -79,7 +79,7 @@ def test_transport_POST_gives_data_to_socket():
 
     expected = deque(['Greetings, program!'])
     actual = transport.socket.incoming.queue
-    assert actual == expected, actual
+    assert actual == expected
 
 def test_transport_GET_gets_data_from_socket():
     transport = make_transport(state=1)
@@ -91,7 +91,7 @@ def test_transport_GET_gets_data_from_socket():
 
     expected = FFFD+b'23'+FFFD+b'3:::Greetings, program!'
     actual = response.body.next()
-    assert actual == expected, actual
+    assert actual == expected
 
 def test_transport_GET_blocks_for_empty_socket():
     transport = make_transport(state=1)
@@ -103,7 +103,7 @@ def test_transport_GET_blocks_for_empty_socket():
 
     expected = transport.timeout
     actual = round(end - start, 4)
-    assert actual > expected, actual
+    assert actual > expected
 
 def test_transport_handles_roundtrip():
     transport = make_transport(state=1, content="socket.send(socket.recv())")
@@ -117,7 +117,7 @@ def test_transport_handles_roundtrip():
 
     expected = FFFD+b"18"+FFFD+b"3::/echo.sock:ping"
     actual = response.body.next()
-    assert actual == expected, actual
+    assert actual == expected
 
 
 

--- a/tests/test_utils.py
+++ b/tests/test_utils.py
@@ -17,11 +17,11 @@ def test_garbage_is_garbage():
 def test_repr_error_strategy_works():
     errors = 'repr'
     actual = GARBAGE.decode('utf8', errors)
-    assert actual == r"\xef\xf9", actual
+    assert actual == r"\xef\xf9"
 
 def test_unicode_dammit_works():
     actual = unicode_dammit(b"foo\xef\xfar")
-    assert actual == r"foo\xef\xfar", actual
+    assert actual == r"foo\xef\xfar"
 
 def test_unicode_dammit_fails():
     assert_raises(TypeError, unicode_dammit, 1)
@@ -30,25 +30,25 @@ def test_unicode_dammit_fails():
 
 def test_unicode_dammit_decodes_utf8():
     actual = unicode_dammit(b"comet: \xe2\x98\x84")
-    assert actual == u"comet: \u2604", actual
+    assert actual == u"comet: \u2604"
 
 def test_unicode_dammit_takes_encoding():
     actual = unicode_dammit(b"comet: \xe2\x98\x84", encoding="ASCII")
-    assert actual == r"comet: \xe2\x98\x84", actual
+    assert actual == r"comet: \xe2\x98\x84"
 
 def test_ascii_dammit_works():
     actual = ascii_dammit(b"comet: \xe2\x98\x84")
-    assert actual == r"comet: \xe2\x98\x84", actual
+    assert actual == r"comet: \xe2\x98\x84"
 
 def test_to_age_barely_works():
     actual = to_age(utcnow())
-    assert actual == "just a moment ago", actual
+    assert actual == "just a moment ago"
 
 def test_to_age_fails():
     assert_raises(ValueError, to_age, datetime.utcnow())
 
 def test_to_age_formatting_works():
     actual = to_age(utcnow(), fmt_past="Cheese, for %(age)s!")
-    assert actual == "Cheese, for just a moment!", actual
+    assert actual == "Cheese, for just a moment!"
 
 

--- a/tests/test_website.py
+++ b/tests/test_website.py
@@ -18,7 +18,7 @@ def test_basic():
     website = Website([])
     expected = os.getcwd()
     actual = website.www_root
-    assert actual == expected, actual
+    assert actual == expected
 
 def test_normal_response_is_returned():
     mk(('index.html', "Greetings, program!"))
@@ -29,44 +29,44 @@ Content-Type: text/html
 Greetings, program!
 """.splitlines())
     actual = handle()._to_http('1.1')
-    assert actual == expected, actual
+    assert actual == expected
 
 def test_fatal_error_response_is_returned():
     mk(('index.html.spt', "raise heck\n[---]\n"))
     expected = 500
     actual = handle().code
-    assert actual == expected, actual
+    assert actual == expected
 
 def test_redirect_has_only_location():
     mk(('index.html.spt', "from aspen import Response\n[---]\nrequest.redirect('http://elsewhere', code=304)\n[---]\n"))
     actual = handle()
     assert actual.code == 304
     headers = actual.headers
-    assert len(headers) == 1, headers
-    assert headers.get('Location') is not None, headers
+    assert len(headers) == 1
+    assert headers.get('Location') is not None
 
 def test_nice_error_response_is_returned():
     mk(('index.html.spt', "from aspen import Response\n[---]\nraise Response(500)\n[---]\n"))
     expected = 500
     actual = handle().code
-    assert actual == expected, actual
+    assert actual == expected
 
 def test_nice_error_response_is_returned_for_404():
     mk(('index.html.spt', "from aspen import Response\n[---]\nraise Response(404)\n[---]\n"))
     expected = 404
     actual = handle().code
-    assert actual == expected, actual
+    assert actual == expected
 
 def test_autoindex_response_is_404_by_default():
     mk(('README', "Greetings, program!"))
     expected = 404
     actual = handle().code
-    assert actual == expected, actual
+    assert actual == expected
 
 def test_autoindex_response_is_returned():
     mk(('README', "Greetings, program!"))
     body = handle('/', '--list_directories=TrUe').body
-    assert 'README' in body, body
+    assert 'README' in body
 
 def test_resources_can_import_from_dot_aspen():
     mk( '.aspen'
@@ -76,7 +76,7 @@ def test_resources_can_import_from_dot_aspen():
     expected = "Greetings, baz!"
     project_root = os.path.join(FSFIX, '.aspen')
     actual = handle('/', '--project_root='+project_root).body
-    assert actual == expected, actual
+    assert actual == expected
 
 
 def test_double_failure_still_sets_response_dot_request():
@@ -100,7 +100,7 @@ def bar(response):
 
     expected = 500
     actual = response.code
-    assert actual == expected, actual
+    assert actual == expected
 
 
 def test_website_doesnt_clobber_outbound():
@@ -114,7 +114,7 @@ def test_website_doesnt_clobber_outbound():
 
     expected = 2
     actual = len(website.hooks.outbound)
-    assert actual == expected, actual
+    assert actual == expected
 
 
 class TestMiddleware(object):
@@ -147,12 +147,12 @@ def test_call_wraps_wsgi_middleware():
     website.wsgi_app = TestMiddleware(website.wsgi_app)
     respond = [False, False]
     def start_response_should_404(status, headers):
-        assert status.lower().strip() == '404 not found', status
+        assert status.lower().strip() == '404 not found'
         respond[0] = True
     website(build_environ('/'), start_response_should_404)
     assert respond[0]
     def start_response_should_200(status, headers):
-        assert status.lower().strip() == '200 ok', status
+        assert status.lower().strip() == '200 ok'
         respond[1] = True
     website(build_environ('/middleware'), start_response_should_200)
     assert respond[1]


### PR DESCRIPTION
Strip a bunch of unnecessary stuff from tests.
