### PR TITLE
Move the teardown into a pytest fixture

### DIFF
--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -1,6 +1,12 @@
 import pytest
 from aspen.testing import fsfix
+from aspen.testing.fsfix import teardown
+
 
 @pytest.yield_fixture
 def mk():
     yield fsfix.mk
+
+def pytest_runtest_teardown():
+    teardown()
+

--- a/tests/test_charset_re.py
+++ b/tests/test_charset_re.py
@@ -4,7 +4,6 @@ from __future__ import print_function
 from __future__ import unicode_literals
 
 from aspen.http.response import charset_re
-from aspen.testing import teardown_function
 
 
 m = lambda s: charset_re.match(s) is not None

--- a/tests/test_configuration.py
+++ b/tests/test_configuration.py
@@ -12,7 +12,7 @@ import aspen
 from aspen.configuration import Configurable, ConfigurationError, parse
 from aspen.configuration.options import OptionParser, DEFAULT
 from aspen.testing import StubRequest, fix
-from aspen.testing.fsfix import teardown_function, FSFIX
+from aspen.testing.fsfix import FSFIX
 #from aspen.testing import handle
 from aspen.website import Website
 

--- a/tests/test_dispatcher.py
+++ b/tests/test_dispatcher.py
@@ -10,7 +10,7 @@ from pytest import raises
 from aspen import dispatcher, Response
 from aspen.http.request import Request
 from aspen.testing import handle, NoException, StubRequest
-from aspen.testing import teardown_function, fix
+from aspen.testing import fix
 
 # Helpers
 # =======

--- a/tests/test_execution.py
+++ b/tests/test_execution.py
@@ -4,7 +4,6 @@ from __future__ import print_function
 from __future__ import unicode_literals
 
 from aspen import execution
-from aspen.testing.fsfix import teardown_function
 
 class Foo:
     pass

--- a/tests/test_hooks.py
+++ b/tests/test_hooks.py
@@ -4,7 +4,6 @@ from __future__ import print_function
 from __future__ import unicode_literals
 
 from aspen.hooks import Hooks
-from aspen.testing import teardown_function
 
 
 def test_hooks_is_barely_instantiable():

--- a/tests/test_json_resource.py
+++ b/tests/test_json_resource.py
@@ -9,7 +9,6 @@ from pytest import raises
 
 from aspen import json
 from aspen.testing import check
-from aspen.testing.fsfix import teardown_function
 
 
 def test_json_basically_works():

--- a/tests/test_mappings.py
+++ b/tests/test_mappings.py
@@ -6,7 +6,6 @@ from __future__ import unicode_literals
 from pytest import raises
 
 from aspen import Response
-from aspen.testing import teardown_function
 
 from aspen.http.mapping import Mapping, CaseInsensitiveMapping
 

--- a/tests/test_negotiated_resource.py
+++ b/tests/test_negotiated_resource.py
@@ -8,7 +8,7 @@ from pytest import raises
 from aspen import resources, Response
 from aspen.resources.pagination import Page
 from aspen.resources.negotiated_resource import NegotiatedResource
-from aspen.testing import teardown_function, handle, StubRequest
+from aspen.testing import handle, StubRequest
 from aspen.website import Website
 from aspen.renderers.stdlib_template import Factory as TemplateFactory
 from aspen.renderers.stdlib_percent import Factory as PercentFactory

--- a/tests/test_request.py
+++ b/tests/test_request.py
@@ -9,7 +9,6 @@ from aspen import Response
 from aspen.http.request import kick_against_goad, Request
 from aspen.http.baseheaders import BaseHeaders
 from aspen.testing import StubRequest
-from aspen.testing.fsfix import teardown_function
 
 
 def test_request_line_raw_works():

--- a/tests/test_request_line.py
+++ b/tests/test_request_line.py
@@ -9,7 +9,6 @@ from aspen import Response
 from aspen.http.request import Request
 from aspen.http.mapping import Mapping
 from aspen.http.request import Line, Method, URI, Version, Path, Querystring
-from aspen.testing import teardown_function
 
 
 # Line

--- a/tests/test_resources.py
+++ b/tests/test_resources.py
@@ -8,7 +8,6 @@ from pytest import raises
 
 from aspen import Response
 from aspen.testing import check, handle
-from aspen.testing.fsfix import teardown_function
 from aspen.resources.pagination import split
 
 

--- a/tests/test_response.py
+++ b/tests/test_response.py
@@ -6,7 +6,6 @@ from __future__ import unicode_literals
 from pytest import raises
 
 from aspen import Response
-from aspen.testing.fsfix import teardown_function
 from aspen.exceptions import CRLFInjection
 
 

--- a/tests/test_sockets_.py
+++ b/tests/test_sockets_.py
@@ -5,7 +5,6 @@ from __future__ import unicode_literals
 
 from aspen import sockets
 from aspen.http.request import Request
-from aspen.testing import teardown_function
 from aspen.testing.sockets import make_request
 
 

--- a/tests/test_sockets_buffer.py
+++ b/tests/test_sockets_buffer.py
@@ -2,7 +2,6 @@ from aspen.sockets import FFFD
 from aspen.sockets.buffer import ThreadedBuffer as Buffer
 from aspen.sockets.message import Message
 from aspen.testing.sockets import make_socket
-from aspen.testing.fsfix import teardown_function
 
 
 def test_buffer_is_instantiable(mk):

--- a/tests/test_sockets_channel.py
+++ b/tests/test_sockets_channel.py
@@ -6,7 +6,6 @@ from aspen.sockets.buffer import ThreadedBuffer
 from aspen.sockets.channel import Channel
 from aspen.sockets.message import Message
 from aspen.testing.sockets import make_socket
-from aspen.testing.fsfix import teardown_function
 
 
 def test_channel_is_instantiable():

--- a/tests/test_sockets_message.py
+++ b/tests/test_sockets_message.py
@@ -6,7 +6,6 @@ from __future__ import unicode_literals
 from pytest import raises
 
 from aspen.sockets.message import Message
-from aspen.testing import teardown_function
 
 
 def test_message_can_be_instantiated_from_bytes():

--- a/tests/test_sockets_packet.py
+++ b/tests/test_sockets_packet.py
@@ -8,7 +8,6 @@ from pytest import raises
 from aspen.sockets import FFFD
 from aspen.sockets.packet import Packet
 from aspen.sockets.message import Message
-from aspen.testing import teardown_function
 
 
 def test_packet_Packetable_with_unframed_bytes():

--- a/tests/test_sockets_socket.py
+++ b/tests/test_sockets_socket.py
@@ -7,7 +7,6 @@ import time
 
 from aspen.sockets import FFFD
 from aspen.sockets.socket import Socket
-from aspen.testing.fsfix import teardown_function
 from aspen.testing.sockets import make_socket, SocketInThread
 
 

--- a/tests/test_sockets_transport.py
+++ b/tests/test_sockets_transport.py
@@ -14,7 +14,6 @@ from aspen.sockets import FFFD
 from aspen.sockets.transport import XHRPollingTransport
 from aspen.sockets.message import Message
 from aspen.testing.sockets import make_socket, make_request
-from aspen.testing.fsfix import teardown_function
 
 
 @pytest.yield_fixture

--- a/tests/test_utils.py
+++ b/tests/test_utils.py
@@ -6,7 +6,6 @@ from __future__ import unicode_literals
 from pytest import raises
 
 import aspen.utils # this happens to install the 'repr' error strategy
-from aspen.testing import teardown_function
 from aspen.utils import ascii_dammit, unicode_dammit, to_age, utcnow
 from datetime import datetime
 

--- a/tests/test_website.py
+++ b/tests/test_website.py
@@ -7,7 +7,7 @@ import os
 import StringIO
 
 from aspen.testing import handle, StubRequest
-from aspen.testing.fsfix import teardown_function, FSFIX
+from aspen.testing.fsfix import FSFIX
 from aspen.website import Website
 
 


### PR DESCRIPTION
Move the teardown function into a pytest fixture so it doesn't have to be imported into every test module.
