### PR TITLE
Use python from virtualenv

### DIFF
--- a/release.sh
+++ b/release.sh
@@ -43,8 +43,8 @@ else
         git push
         git push --tags
 
-        ./env/bin/python setup.py sdist --formats=zip,gztar,bztar upload
-        ./env/bin/python setup.py bdist_wheel upload
+        python setup.py sdist --formats=zip,gztar,bztar upload
+        python setup.py bdist_wheel upload
 
         printf "\055dev" >> version.txt
         git commit version.txt -m"Bump version to $1-dev"


### PR DESCRIPTION
We're using an old version of virtualenv (1.7.1.2) that doesn't include
a python2.7 in bin. The result is that our release script to date has
used whatever python2.7 was available on PATH. This is problematic
because we need to have wheel installed for the python we're using to
release. Best to use the virtualenv python for the release.

We should add a check for whether we're actually in the virtualenv.
Maybe if $PS1 ends with "[aspen] "?

We should probably also upgrade virtualenv.
