### PR TITLE
Kill module scrubber

### DIFF
--- a/aspen/testing/pytest_fixtures.py
+++ b/aspen/testing/pytest_fixtures.py
@@ -18,15 +18,6 @@ def fs():
 
 
 @pytest.yield_fixture
-def module_scrubber():
-    before = set(sys.modules.keys())
-    yield
-    after = set(sys.modules.keys())
-    for name in after - before:
-        del sys.modules[name]
-
-
-@pytest.yield_fixture
 def sys_path_scrubber():
     before = set(sys.path)
     yield
@@ -36,13 +27,13 @@ def sys_path_scrubber():
 
 
 @pytest.yield_fixture
-def sys_path(fs, module_scrubber):
+def sys_path(fs):
     sys.path.insert(0, fs.root)
     yield fs
 
 
 @pytest.yield_fixture
-def harness(module_scrubber, sys_path_scrubber):
+def harness(sys_path_scrubber):
     harness = Harness()
     yield harness
     harness.teardown()

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -1,5 +1,5 @@
 from aspen.testing.harness import teardown
-from aspen.testing.pytest_fixtures import client, harness, fs, module_scrubber
+from aspen.testing.pytest_fixtures import client, harness, fs
 from aspen.testing.pytest_fixtures import sys_path, sys_path_scrubber
 
 


### PR DESCRIPTION
This is mucking with global module state (or something?) in a way that
is effing up tests over in aspen-python-plugins. The aspen test suite
runs without it, so we're nuking it.
