### PR TITLE
Here's a simpler implemention of #249

### DIFF
--- a/aspen/exceptions.py
+++ b/aspen/exceptions.py
@@ -6,6 +6,8 @@ from __future__ import division
 from __future__ import print_function
 from __future__ import unicode_literals
 
+from aspen import Response
+
 
 class LoadError(Exception):
     """Represent a problem loading a resource.
@@ -13,6 +15,9 @@ class LoadError(Exception):
     # Define this here to avoid import issues when json doesn't exist.
 
 
-class CRLFInjection(Exception):
-    def __str__(self):
-        return "Possible CRLF injection detected."
+class CRLFInjection(Response):
+    """
+    A 400 Response (per #249) raised if there's a suspected CRLF Injection attack in the headers
+    """
+    def __init__(self):
+        Response.__init__(self, code=400, body="Possible CRLF Injection detected.")

--- a/aspen/http/baseheaders.py
+++ b/aspen/http/baseheaders.py
@@ -6,7 +6,6 @@ from __future__ import unicode_literals
 
 from aspen.backcompat import CookieError, SimpleCookie
 
-from aspen.exceptions import CRLFInjection
 from aspen.http.mapping import CaseInsensitiveMapping
 from aspen.utils import typecheck
 
@@ -48,7 +47,8 @@ class BaseHeaders(CaseInsensitiveMapping):
 
         """
         if '\n' in value:
-            raise CRLFInjection
+            from aspen.exceptions import CRLFInjection
+            raise CRLFInjection()
         super(BaseHeaders, self).__setitem__(name, value)
 
 


### PR DESCRIPTION
This avoids a circular import by burying an import rather than folding two files together (#275).
