### PR TITLE
Only support negotiated simplates for errors

### DIFF
--- a/aspen/algorithms/website.py
+++ b/aspen/algorithms/website.py
@@ -106,7 +106,7 @@ def delegate_error_to_simplate(website, request, response):
         return
 
     code = str(response.code)
-    possibles = [code + ".html", code + ".html.spt", "error.html", "error.html.spt"]
+    possibles = [code + ".spt", "error.spt"]
     fs = _first(website.ours_or_theirs(errpage) for errpage in possibles)
 
     if fs is not None:

--- a/aspen/www/error.spt
+++ b/aspen/www/error.spt
@@ -36,7 +36,7 @@ else:
 
 msg_title = msg.title()
 
-[----------------------------------------] via stdlib_format
+[----------------------------------------] text/html via stdlib_format
 <html>
     <head>
         <title>{response.code} {msg_title}</title>

--- a/tests/test_website.py
+++ b/tests/test_website.py
@@ -63,8 +63,8 @@ raise Response(404)
 [---]"""))
     assert harness.client.GET(raise_immediately=False).code == 404
 
-def test_nice_error_response_can_come_from_user_error_html(harness):
-    harness.fs.project.mk(('error.html', 'Told ya.'))
+def test_nice_error_response_can_come_from_user_error_spt(harness):
+    harness.fs.project.mk(('error.spt', '[---]\n[---] text/plain\nTold ya.'))
     harness.fs.www.mk(('index.html.spt', """
 from aspen import Response
 [---]
@@ -74,10 +74,11 @@ raise Response(420)
     assert response.code == 420
     assert response.body == 'Told ya.'
 
-def test_nice_error_response_can_come_from_user_420_html(harness):
-    harness.fs.project.mk(('420.html.spt', """
-msg = "Enhance your calm." if response.code == 420 else "Ok."
+def test_nice_error_response_can_come_from_user_420_spt(harness):
+    harness.fs.project.mk(('420.spt', """
 [---]
+msg = "Enhance your calm." if response.code == 420 else "Ok."
+[---] text/plain
 %(msg)s"""))
     harness.fs.www.mk(('index.html.spt', """
 from aspen import Response

--- a/tests/test_website_flow.py
+++ b/tests/test_website_flow.py
@@ -10,5 +10,5 @@ def test_website_can_respond(harness):
 
 
 def test_404_comes_out_404(harness):
-    harness.fs.project.mk(('404.html.spt', 'Eep!'))
+    harness.fs.project.mk(('404.spt', '[---]\n[---] text/plain\nEep!'))
     assert harness.client.GET(raise_immediately=False).code == 404


### PR DESCRIPTION
This is a step on the way to addressing #279. It makes error handling a lot simpler if we don't look for {$code,error}{.$ext,.$ext.spt,.spt}, where $ext is infinitely variable. Instead we look just for {$code,error}.spt. Eventually we may decide to simplify non-error simplates the same way: only .spt, no special-casing of .$ext.spt on the filesystem (#286). For now though the next step for #279 would be to update the Accept header of the internal redirect in
delegate_error_to_simplate to enforce the media type that had been negotiated to begin with.
