### PR TITLE
Relax reqs to allow future versions of pkgs

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -40,9 +40,9 @@ setup( author = 'Chad Whitacre'
      , version = version
      , zip_safe = False
      , package_data = {'aspen': ['www/*', 'configuration/mime.types']}
-     , install_requires = [ 'Cheroot==4.0.0beta'
-                          , 'mimeparse==0.1.3'
-                          , 'first==2.0.1'
+     , install_requires = [ 'Cheroot>=4.0.0beta'
+                          , 'mimeparse>=0.1.3'
+                          , 'first>=2.0.0'
                           , 'algorithm>=1.0.0'
                           , 'filesystem_tree>=1.0.0'
                            ]


### PR DESCRIPTION
This is useful for a number of reasons.

Firstly, Cheroot was released with a version hosted on PyPI, but its version is [not exactly 4.0.0beta](https://pypi.python.org/pypi/Cheroot). Thus pip >=1.5 would still fail to install aspen cleanly with an exact version specified (as it is currently). This also obviously allows a stable version of Cheroot to be installed, if/when that is released.

Another funny situation is the case for `mimeparse`... 0.1.3 is available on PyPI, but 0.1.4 is hosted externally. specifying >= allows 0.1.4 to be installed when that might be available directly on PyPI.

For a great discussion on requirements in setup.py vs in requirements.txt, check out [Donald Stufft's article](https://caremad.io/blog/setup-vs-requirement/) (he maintains pip and virtualenv).
