### PR TITLE
Fix some tests that didn't mock requests enough

### DIFF
--- a/tests/test_request_body.py
+++ b/tests/test_request_body.py
@@ -19,6 +19,8 @@ def make_body(raw, headers=None, content_type=WWWFORM):
         elif content_type is WWWFORM:
             content_type = "application/x-www-form-urlencoded"
         headers = {"Content-Type": content_type}
+    if not 'content-length' in headers:
+        headers['Content-length'] = str(len(raw))
     headers['Host'] = 'Blah'
     return Body( Headers(headers)
                , StringIO(raw)

--- a/tests/test_sockets_transport.py
+++ b/tests/test_sockets_transport.py
@@ -8,7 +8,7 @@ from collections import deque
 from cStringIO import StringIO
 
 from aspen import Response
-from aspen.http.request import Request
+from aspen.http.request import Request, Headers
 from aspen.sockets import FFFD
 from aspen.sockets.transport import XHRPollingTransport
 from aspen.sockets.message import Message
@@ -58,9 +58,11 @@ def test_transport_stays_in_state_1_after_second_request(harness):
 def test_transport_POST_gives_data_to_socket(harness):
     transport = harness.make_transport(state=1)
 
+    msg = b'3::/echo.sock:Greetings, program!'
     request = Request( 'POST'
                      , '/echo.sock'
-                     , body=StringIO(b'3::/echo.sock:Greetings, program!')
+                     , body=StringIO(msg)
+		     , headers={'content-length' : str(len(msg)), 'Host': 'Testhost' }
                       )
     transport.respond(request)
 
@@ -94,8 +96,9 @@ def test_transport_GET_blocks_for_empty_socket(harness):
 
 def test_transport_handles_roundtrip(harness):
     transport = harness.make_transport(state=1, content="socket.send(socket.recv())")
-
-    request = Request('POST', '/echo.sock', body=StringIO(b"3::/echo.sock:ping"))
+    msg = b"3::/echo.sock:ping"
+    request = Request('POST', '/echo.sock', body=StringIO(msg), 
+	    headers={ 'content-length' : str(len(msg)), 'Host': 'Testhost' })
     transport.respond(request)
     transport.socket.tick() # do it manually
 


### PR DESCRIPTION
Real requests always have content-length, which
these didn't, so the previous fix where we switch to
always reading a length based on the specified content-length
broke them.
