### PR TITLE
added Scripts dir use on Windows

### DIFF
--- a/build.py
+++ b/build.py
@@ -38,7 +38,10 @@ ENV_ARGS = [
 
 
 def _virt(cmd, envdir='env'):
-    return os.path.join(envdir, 'bin', cmd)
+    if os.name == "nt":
+        return os.path.join(envdir, 'Scripts', cmd+ '.exe')
+    else:
+        return os.path.join(envdir, 'bin', cmd)
 
 
 def _virt_version():


### PR DESCRIPTION
@pjz here's what I added to get `python build.py test` to run on Windows.

Mind you, the tests don't all pass...but at least they run. :smile_cat: 
