### PR TITLE
Make Cheroot dep not complain on 'pip install'

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -40,7 +40,7 @@ setup( author = 'Chad Whitacre'
      , version = version
      , zip_safe = False
      , package_data = {'aspen': ['www/*', 'configuration/mime.types']}
-     , install_requires = [ 'Cheroot==4.0.0beta'
+     , install_requires = [ 'Cheroot<4'
                           , 'mimeparse==0.1.3'
                           , 'first==2.0.1'
                           , 'algorithm>=1.0.0'


### PR DESCRIPTION
Fix #312: Change to a version of Cheroot that still supports Python 2.6
and doesn't need any extra flags to allow installation.
