### PR TITLE
Fix utils.to_rfc822()

### DIFF
--- a/aspen/utils.py
+++ b/aspen/utils.py
@@ -11,8 +11,6 @@ import codecs
 import datetime
 import math
 import re
-import time
-from email import utils as email_utils
 
 import algorithm
 
@@ -198,14 +196,21 @@ def to_age(dt, fmt_past=None, fmt_future=None):
 def to_rfc822(dt):
     """Given a datetime.datetime, return an RFC 822-formatted unicode.
 
-        Sun, 06 Nov 1994 08:49:37 -0000
+        Sun, 06 Nov 1994 08:49:37 GMT
 
     According to RFC 1123, day and month names must always be in English. If
     not for that, this code could use strftime(). It can't because strftime()
     honors the locale and could generated non-English names.
 
     """
-    return email_utils.formatdate(time.mktime(dt.timetuple())).decode('US-ASCII')
+    t = dt.utctimetuple()
+    return '%s, %02d %s %04d %02d:%02d:%02d GMT' % (
+        ('Mon', 'Tue', 'Wed', 'Thu', 'Fri', 'Sat', 'Sun')[t[6]],
+        t[2],
+        ('Jan', 'Feb', 'Mar', 'Apr', 'May', 'Jun',
+         'Jul', 'Aug', 'Sep', 'Oct', 'Nov', 'Dec')[t[1] - 1],
+        t[0], t[3], t[4], t[5]
+    )
 
 
 # Filters

--- a/tests/test_utils.py
+++ b/tests/test_utils.py
@@ -6,7 +6,7 @@ from __future__ import unicode_literals
 from pytest import raises
 
 import aspen.utils # this happens to install the 'repr' error strategy
-from aspen.utils import ascii_dammit, unicode_dammit, to_age, utcnow
+from aspen.utils import ascii_dammit, unicode_dammit, to_age, to_rfc822, utcnow
 from datetime import datetime
 
 GARBAGE = b"\xef\xf9"
@@ -52,4 +52,7 @@ def test_to_age_formatting_works():
     actual = to_age(utcnow(), fmt_past="Cheese, for %(age)s!")
     assert actual == "Cheese, for just a moment!"
 
-
+def test_to_rfc822():
+    expected = 'Thu, 01 Jan 1970 00:00:00 GMT'
+    actual = to_rfc822(datetime(1970, 1, 1))
+    assert actual == expected


### PR DESCRIPTION
Per [RFC2616 section 3.3.1](http://tools.ietf.org/html/rfc2616#section-3.3.1), the dates in HTTP must always end in `GMT`, the numerical notation for the timezone is not valid.

Also, instead of calling `email.utils.formatdate` which forces us to do a needless conversion of our `datetime` to a `float` and does other stuff we don't need, I just copied the relevant code from `email.utils.formatdate`, probably making the function a bit faster and gaining python 3 compatibility at the same time (by removing the need for the `.decode()` call).
