### PR TITLE
Stop accepting bad headers; fixes #369

### DIFF
--- a/aspen/exceptions.py
+++ b/aspen/exceptions.py
@@ -24,3 +24,13 @@ class CRLFInjection(Response):
     """
     def __init__(self):
         Response.__init__(self, code=400, body="Possible CRLF Injection detected.")
+
+
+class MalformedHeader(Response):
+    """
+    A 400 Response (per http://tools.ietf.org/html/rfc7230#section-3.2.4) raised
+    if there's no : in a header field, or if there's leading or trailing
+    whitespace in the key part of a header field
+    """
+    def __init__(self, header):
+        Response.__init__(self, code=400, body="Malformed header: %s" % header)

--- a/aspen/http/baseheaders.py
+++ b/aspen/http/baseheaders.py
@@ -26,14 +26,22 @@ class BaseHeaders(CaseInsensitiveMapping):
         """
         typecheck(d, (dict, str))
         if isinstance(d, str):
+            from aspen.exceptions import MalformedHeader
+
             def genheaders():
                 for line in d.splitlines():
+                    if b':' not in line:
+                        # no colon separator in header
+                        raise MalformedHeader(line)
                     k, v = line.split(b':', 1)
-                    yield k.strip(), v.strip()
+                    if k != k.strip():
+                        # disallowed leading or trailing whitspace
+                        # (per http://tools.ietf.org/html/rfc7230#section-3.2.4)
+                        raise MalformedHeader(line)
+                    yield k, v.strip()
         else:
             genheaders = d.iteritems
         CaseInsensitiveMapping.__init__(self, genheaders)
-
 
         # Cookie
         # ======
@@ -42,7 +50,7 @@ class BaseHeaders(CaseInsensitiveMapping):
         try:
             self.cookie.load(self.get('Cookie', b''))
         except CookieError:
-            pass # XXX really?
+            pass  # XXX really?
 
 
     def __setitem__(self, name, value):

--- a/tests/test_request.py
+++ b/tests/test_request.py
@@ -8,6 +8,7 @@ from pytest import raises
 from aspen import Response
 from aspen.http.request import make_franken_headers, kick_against_goad, Request
 from aspen.http.baseheaders import BaseHeaders
+from aspen.exceptions import MalformedHeader
 
 
 def test_request_line_raw_works(harness):
@@ -112,6 +113,12 @@ def test_headers_dont_unicodify_cookie():
     expected = b"somecookiedata"
     actual = headers[b'Cookie']
     assert actual == expected
+
+def test_headers_handle_no_colon():
+    raises(MalformedHeader, BaseHeaders, b"Foo Bar")
+
+def test_headers_handle_bad_spaces():
+    raises(MalformedHeader, BaseHeaders, b"Foo : Bar")
 
 
 # kick_against_goad


### PR DESCRIPTION
We now defend against missing :'s and also leading/trailing whitespace on the key side of the k:v pair.
