### PR TITLE
Add sphinx build target back to build.py

### DIFF
--- a/docs/Makefile
+++ b/docs/Makefile
@@ -151,3 +151,7 @@ doctest:
 	$(SPHINXBUILD) -b doctest $(ALLSPHINXOPTS) $(BUILDDIR)/doctest
 	@echo "Testing of doctests in the sources finished, look at the " \
 	      "results in $(BUILDDIR)/doctest/output.txt."
+
+livehtml:
+	sphinx-autobuild -b html $(ALLSPHINXOPTS) $(BUILDDIR)/html || echo "sphinx-autobuild not installed."
+


### PR DESCRIPTION
Also add a livehtml target to the makefile to support sphinx-autobuild

sphinx now uses its own separate virtualenv in the `denv` directory to avoid causing conflicts with any aspen requirements.
