### PR TITLE
Don't return a 415 when the body is empty

### DIFF
--- a/aspen/body_parsers.py
+++ b/aspen/body_parsers.py
@@ -69,6 +69,8 @@ def parse_body(raw, headers, parsers):
     content_type = headers.get("Content-Type", "").split(';')[0]
 
     def default_parser(raw, headers):
+        if not content_type and not raw:
+            return {}
         raise UnknownBodyType(content_type)
 
     return parsers.get(content_type, default_parser)(raw, headers)


### PR DESCRIPTION
This is a solution for gratipay/gratipay.com#2984 and gratipay/gratipay.com#3004. It seems that when jQuery is asked to make an empty POST request, it doesn't set a `Content-Type`, so Aspen complains about not being able to parse the body, but since there is nothing to parse anyway I think returning an empty dict is a better idea.
