### PR TITLE
Return a 400 when parsing the body of a POST request fails

### DIFF
--- a/aspen/body_parsers.py
+++ b/aspen/body_parsers.py
@@ -14,11 +14,11 @@ Headers mapping of the supplied headers
 """
 
 import cgi
-from aspen import json_ as json
+from aspen import Response, json_ as json
 from aspen.utils import typecheck
 from aspen.http.request import Headers
 from aspen.http.mapping import Mapping
-from aspen.exceptions import UnknownBodyType
+from aspen.exceptions import MalformedBody, UnknownBodyType
 
 def formdata(raw, headers):
     """Parse raw as form data"""
@@ -73,4 +73,7 @@ def parse_body(raw, headers, parsers):
             return {}
         raise UnknownBodyType(content_type)
 
-    return parsers.get(content_type, default_parser)(raw, headers)
+    try:
+        return parsers.get(content_type, default_parser)(raw, headers)
+    except ValueError as e:
+        raise MalformedBody(str(e))

--- a/aspen/exceptions.py
+++ b/aspen/exceptions.py
@@ -35,6 +35,15 @@ class MalformedHeader(Response):
     def __init__(self, header):
         Response.__init__(self, code=400, body="Malformed header: %s" % header)
 
+
+class MalformedBody(Response):
+    """
+    A 400 Response raised if parsing the body of a POST request fails
+    """
+    def __init__(self, msg):
+        Response.__init__(self, code=400, body="Malformed body: %s" % msg)
+
+
 class UnknownBodyType(Response):
     """
     A 415 Response raised if the Content-Type of the body of a POST request

--- a/tests/test_request_body.py
+++ b/tests/test_request_body.py
@@ -7,7 +7,7 @@ from pytest import raises
 
 from aspen.http.request import Headers
 import aspen.body_parsers as parsers
-from aspen.exceptions import UnknownBodyType
+from aspen.exceptions import MalformedBody, UnknownBodyType
 
 
 FORMDATA = object()
@@ -23,6 +23,7 @@ def make_body(raw, headers=None, content_type=WWWFORM):
     if not 'content-length' in headers:
         headers['Content-length'] = str(len(raw))
     body_parsers = {
+            "application/json": parsers.jsondata,
             "application/x-www-form-urlencoded": parsers.formdata,
             "multipart/form-data": parsers.formdata
     }
@@ -69,3 +70,11 @@ def test_params_doesnt_break_www_form():
                      )
     actual = body['statement']
     assert actual == "foo"
+
+def test_malformed_body_jsondata():
+    with raises(MalformedBody):
+        make_body("foo", content_type="application/json")
+
+def test_malformed_body_formdata():
+    with raises(MalformedBody):
+        make_body("", content_type="multipart/form-data; boundary=\0")


### PR DESCRIPTION
We want to return a 400 instead of letting the body parser cause a 500. Found the problem in https://app.getsentry.com/gratipay/gratipay-com/group/45028306/
