### PR TITLE
Improve build.py for better DevX

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -8,7 +8,7 @@ python:
 before_install:
   - pip install --upgrade pip
   - pip --version
-install: python build.py deps
+install: python build.py dev
 script: python build.py analyse
 notifications:
   email: false

--- a/appveyor.yml
+++ b/appveyor.yml
@@ -15,8 +15,8 @@ install:
   - "python --version"
   - "python -c \"import struct; print(struct.calcsize('P') * 8)\""
 
-  # Install the build dependencies of the project.
-  - "python setup.py -q install"
+  # Install the project and its dependencies.
+  - "python build.py dev"
 
 build: false  # Not a C# project, build stuff at the test step instead.
 


### PR DESCRIPTION
- `pip install --editable .` breaks fabricate's caching, so check first whether aspen is already installed using `pip show`
- instead of calling `pip install` for each dependency in a list, call it once with the whole list
- update the CI scripts to use `build.py dev`

(I'm not sure why I didn't push this branch back in March, don't ask. :D)