### PR TITLE
Stop serializing HTTP headers received via WSGI

### DIFF
--- a/pando/http/request.py
+++ b/pando/http/request.py
@@ -103,10 +103,10 @@ def make_franken_uri(path, qs):
 
 def make_franken_headers(environ):
     """Takes a WSGI environ, returns a dict of HTTP headers.
+
+    https://www.python.org/dev/peps/pep-3333/#environ-variables
     """
 
-    # There are a couple keys that CherryPyWSGIServer explicitly doesn't
-    # include as HTTP_ keys. I'm not sure why, but I believe we want them.
     also = [b'CONTENT_TYPE', b'CONTENT_LENGTH']
 
     headers = []

--- a/pando/http/request.py
+++ b/pando/http/request.py
@@ -106,22 +106,11 @@ def make_franken_headers(environ):
 
     https://www.python.org/dev/peps/pep-3333/#environ-variables
     """
-
-    also = [b'CONTENT_TYPE', b'CONTENT_LENGTH']
-
-    headers = []
-    for k, v in environ.items():
-        val = None
-        if k.startswith(b'HTTP_'):
-            k = k[len(b'HTTP_'):]
-            val = v
-        elif k in also:
-            val = v
-        if val is not None:
-            k = k.replace(b'_', b'-')
-            headers.append((k, v))
-
-    return dict(headers)
+    headers = [(k[5:], v) for k, v in environ.items() if k[:5] == b'HTTP_']
+    headers.extend(
+        (k, environ.get(k, None)) for k in (b'CONTENT_TYPE', b'CONTENT_LENGTH')
+    )
+    return dict((k.replace(b'_', b'-'), v) for k, v in headers if v is not None)
 
 
 def kick_against_goad(environ):

--- a/pando/http/request.py
+++ b/pando/http/request.py
@@ -102,7 +102,7 @@ def make_franken_uri(path, qs):
 
 
 def make_franken_headers(environ):
-    """Takes a WSGI environ, returns a bytestring.
+    """Takes a WSGI environ, returns a dict of HTTP headers.
     """
 
     # There are a couple keys that CherryPyWSGIServer explicitly doesn't
@@ -119,9 +119,9 @@ def make_franken_headers(environ):
             val = v
         if val is not None:
             k = k.replace(b'_', b'-')
-            headers.append(b': '.join([k, v]))
+            headers.append((k, v))
 
-    return b'\r\n'.join(headers)
+    return dict(headers)
 
 
 def kick_against_goad(environ):

--- a/tests/test_request.py
+++ b/tests/test_request.py
@@ -168,7 +168,7 @@ def test_goad_passes_method_through():
     environ['SERVER_PROTOCOL'] = b''
     environ['wsgi.input'] = None
 
-    expected = (b'\xdead\xbeef', b'', b'', b'', b'', None)
+    expected = (b'\xdead\xbeef', b'', b'', b'', {}, None)
     actual = kick_against_goad(environ)
     assert actual == expected
 
@@ -180,7 +180,7 @@ def test_goad_makes_franken_uri():
     environ['QUERY_STRING'] = b'foo=bar'
     environ['wsgi.input'] = b''
 
-    expected = ('', '/cheese?foo=bar', '', '', '', '')
+    expected = ('', '/cheese?foo=bar', '', '', {}, '')
     actual = kick_against_goad(environ)
     assert actual == expected
 
@@ -190,7 +190,7 @@ def test_goad_passes_version_through():
     environ['SERVER_PROTOCOL'] = b'\xdead\xbeef'
     environ['wsgi.input'] = None
 
-    expected = (b'', b'', b'', b'\xdead\xbeef', b'', None)
+    expected = (b'', b'', b'', b'\xdead\xbeef', {}, None)
     actual = kick_against_goad(environ)
     assert actual == expected
 
@@ -201,7 +201,7 @@ def test_goad_makes_franken_headers():
     environ['HTTP_FOO_BAR'] = b'baz=buz'
     environ['wsgi.input'] = b''
 
-    expected = (b'', b'', b'', b'', b'FOO-BAR: baz=buz', b'')
+    expected = (b'', b'', b'', b'', {b'FOO-BAR': b'baz=buz'}, b'')
     actual = kick_against_goad(environ)
     assert actual == expected
 
@@ -211,11 +211,11 @@ def test_goad_passes_body_through():
     environ['SERVER_PROTOCOL'] = b''
     environ['wsgi.input'] = b'\xdead\xbeef'
 
-    expected = (b'', b'', b'', b'', b'', b'\xdead\xbeef')
+    expected = (b'', b'', b'', b'', {}, b'\xdead\xbeef')
     actual = kick_against_goad(environ)
     assert actual == expected
 
 
 def test_can_make_franken_headers_from_non_ascii_values():
     actual = make_franken_headers({b'HTTP_FOO_BAR': b'\xdead\xbeef'})
-    assert actual == b'FOO-BAR: \xdead\xbeef'
+    assert actual == {b'FOO-BAR': b'\xdead\xbeef'}


### PR DESCRIPTION
This PR closes #371. I thought it would require more changes, but in fact it's a pretty small patch that doesn't even conflict with my `use-aspen` branch (#548).