### PR TITLE
Fix Response subclassing

### DIFF
--- a/pando/http/response.py
+++ b/pando/http/response.py
@@ -88,7 +88,7 @@ class Response(Exception):
         self.headers.cookie.load(self.headers.get('Cookie', b''))
 
     def __call__(self, environ, start_response):
-        wsgi_status = str(self)
+        wsgi_status = self._status_text()
         for morsel in self.headers.cookie.values():
             self.headers.add('Set-Cookie', morsel.OutputString())
         wsgi_headers = []
@@ -114,9 +114,12 @@ class Response(Exception):
         return CloseWrapper(self.request, body)
 
     def __repr__(self):
-        return "<Response: %s>" % str(self)
+        return "<Response: %s>" % self._status_text()
 
     def __str__(self):
+        return self._status_text()
+
+    def _status_text(self):
         return "%d %s" % (self.code, self._status())
 
     def _status(self):

--- a/tests/test_response.py
+++ b/tests/test_response.py
@@ -17,6 +17,14 @@ def test_response_is_a_wsgi_callable():
     actual = list(response({}, start_response).body)
     assert actual == expected
 
+def test_response_wsgi_status_is_not_based_on_str_method():
+    class CustomResponse(Response):
+        __str__ = lambda self: 'not a valid HTTP status line'
+    response = CustomResponse()
+    def start_response(status, headers):
+        assert status == '200 OK'
+    response({}, start_response)
+
 def test_response_body_can_be_bytestring():
     response = Response(body=b"Greetings, program!")
     expected = "Greetings, program!"
@@ -56,6 +64,3 @@ def test_response_headers_protect_against_crlf_injection():
     def inject():
         response.headers['Location'] = 'foo\r\nbar'
     raises(CRLFInjection, inject)
-
-
-


### PR DESCRIPTION
The `__call__` method of `Response` currently relies on `str(self)` to generate the HTTP status text. That's a bad idea, because if a subclass has its own `__str__` method then the HTTP status returned by `Response.__call__` can be invalid. That's what happened in Liberapay, and it broke our error pages (see https://github.com/liberapay/liberapay.com/issues/362 and https://github.com/liberapay/liberapay.com/issues/365 for details).