### PR TITLE
Prepare first release

### DIFF
--- a/Changelog.md
+++ b/Changelog.md
@@ -1,6 +1,25 @@
 Pando Changelog
 ===============
 
+0.43 - Released Wed Sept 7 2016 by @Changaco
+--------------------------------------------
+
+* rename from Aspen to Pando (#552) and use the new `aspen` library (#556)
+
+* add support for python 3 (#544, #559)
+
+* switch to stdlib `logging` module (#522)
+
+* add no-op functions to website algorithm for easy hookage (#523)
+
+* improve simplate interpretation (#516, #517, #518)
+
+* add all the RFC2616 HTTP methods to the test client (#558)
+
+* allow `Response` subclasses to modify `__str__()` (#555)
+
+* simplify HTTP headers handling (#554)
+
 0.42 - Released Thu Sept 10 2015 by @whit537
 --------------------------------------------
 

--- a/build.py
+++ b/build.py
@@ -16,7 +16,7 @@ PANDO_DEPS = [
     'algorithm>=1.2.0',
     'filesystem_tree>=1.0.1',
     'dependency_injection>=1.1.0',
-    ('aspen', 'https://github.com/AspenWeb/aspen.py/archive/master.zip'),
+    'aspen>=1.0rc1',
     'six',
     ]
 

--- a/release.sh
+++ b/release.sh
@@ -44,7 +44,7 @@ else
         git push --tags
 
         python setup.py sdist --formats=zip,gztar,bztar upload
-        python setup.py bdist_wheel upload
+        python setup.py bdist_wheel --universal upload
 
         printf "\055dev" >> version.txt
         git commit version.txt -m"Bump version to $1-dev"


### PR DESCRIPTION
The plan here is to run Liberapay on top of Pando 0.43 and Aspen 1.0rc1 in production, to try to find any remaining bug before we announce Aspen 1.0 (in less than two weeks).