### PR TITLE
Drop `Response.charset` attribute

### DIFF
--- a/pando/website.py
+++ b/pando/website.py
@@ -100,8 +100,8 @@ class Website(object):
             website.wsgi_app = WSGIMiddleware(website.wsgi_app)
 
         """
-        wsgi = self.respond(environ)['response']
-        return wsgi(environ, start_response)
+        response = self.respond(environ)['response']
+        return response.to_wsgi(environ, start_response, self.charset_dynamic)
 
 
     def respond(self, environ, raise_immediately=None, return_after=None):

--- a/tests/test_response.py
+++ b/tests/test_response.py
@@ -9,12 +9,12 @@ from pando import Response
 from pando.exceptions import CRLFInjection
 
 
-def test_response_is_a_wsgi_callable():
+def test_response_to_wsgi():
     response = Response(body=b"Greetings, program!")
     def start_response(status, headers):
         pass
     expected = [b"Greetings, program!"]
-    actual = list(response({}, start_response).body)
+    actual = list(response.to_wsgi({}, start_response, 'utf8').body)
     assert actual == expected
 
 def test_response_wsgi_status_is_not_based_on_str_method():
@@ -23,7 +23,7 @@ def test_response_wsgi_status_is_not_based_on_str_method():
     response = CustomResponse()
     def start_response(status, headers):
         assert status == '200 OK'
-    response({}, start_response)
+    response.to_wsgi({}, start_response, 'utf8')
 
 def test_response_body_can_be_bytestring():
     response = Response(body=b"Greetings, program!")
@@ -36,7 +36,7 @@ def test_response_body_as_bytestring_results_in_an_iterable():
     def start_response(status, headers):
         pass
     expected = [b"Greetings, program!"]
-    actual = list(response({}, start_response).body)
+    actual = list(response.to_wsgi({}, start_response, 'utf8').body)
     assert actual == expected
 
 def test_response_body_can_be_iterable():
@@ -50,7 +50,7 @@ def test_response_body_as_iterable_comes_through_untouched():
     def start_response(status, headers):
         pass
     expected = [b"Greetings, ", b"program!"]
-    actual = list(response({}, start_response).body)
+    actual = list(response.to_wsgi({}, start_response, 'utf8').body)
     assert actual == expected
 
 def test_response_body_can_be_unicode():
@@ -65,7 +65,7 @@ def test_response_headers_are_str():
     def start_response(status, headers):
         assert isinstance(headers[0][0], str)
         assert isinstance(headers[0][1], str)
-    response({}, start_response)
+    response.to_wsgi({}, start_response, 'utf8')
 
 def test_response_headers_protect_against_crlf_injection():
     response = Response()
@@ -79,4 +79,4 @@ def test_response_cookie():
     def start_response(status, headers):
         assert headers[0][0] == str('Set-Cookie')
         assert headers[0][1].startswith(str('foo=bar'))
-    response({}, start_response)
+    response.to_wsgi({}, start_response, 'utf8')

--- a/tests/test_website.py
+++ b/tests/test_website.py
@@ -375,6 +375,19 @@ def test_call_wraps_wsgi_middleware(client):
     client.website(build_environ('/middleware'), start_response_should_200)
     assert respond[1]
 
+def test_raised_unicode_response_is_encoded_with_configured_charset(harness):
+    harness.fs.www.mk(('index.html.spt', '''
+        from pando import Response
+        [---]
+        raise Response(200, "touch\\u00e9")
+        [---]
+    '''))
+    harness.client.hydrate_website(charset_dynamic='latin9')
+    def start_response(*a):
+        pass
+    body = harness.client.website(build_environ('/'), start_response)
+    assert list(body) == [b'touch\xe9']
+
 
 # redirect
 


### PR DESCRIPTION
This PR will fix the encoding of raised unicode responses, currently the `charset_dynamic` configuration knob isn't respected, instead UTF8 is always used.