### PR TITLE
Make the basic test client stateless

### DIFF
--- a/tests/test_test_client.py
+++ b/tests/test_test_client.py
@@ -25,8 +25,7 @@ def test_test_client_sends_cookies(harness):
     miam = request.headers.cookie[str('miam')].value
     [---] text/plain via stdlib_format
     {miam}'''))
-    harness.client.cookie[str('miam')] = str('a_cookie')
-    response = harness.client.POST('/foo')
+    response = harness.client.POST('/foo', cookies={'miam': 'a_cookie'})
     assert response.body == b'a_cookie'
 
 def test_test_client_handles_file_upload(harness):
@@ -56,3 +55,15 @@ def test_test_client_can_have_file_upload_content_type_overriden(harness):
                              )
     response = harness.client.POST('/foo', data={b'bar': file_upload})
     assert response.body == b'something/else'
+
+def test_stateful_test_client_passes_cookies(harness):
+    harness.fs.www.mk(('foo.spt', '''
+    [---]
+    csrf_token = request.headers.cookie[str('csrf_token')].value
+    session = request.headers.cookie[str('session')].value
+    [---] text/plain via stdlib_format
+    {csrf_token} and {session}'''))
+    with harness.client.get_session() as sess:
+        sess.cookie['csrf_token'] = 'a_csrf_token'
+        response = sess.POST('/foo', cookies={'session': 'a_session_token'})
+        assert response.body == b'a_csrf_token and a_session_token'


### PR DESCRIPTION
This is a breaking change. Experience seems to indicate that keeping cookies is not a good default: Pando's tests don't use this feature, and both Gratipay and Liberapay clear cookies before each request.