### PR TITLE
Bring back `whence_raised`

### DIFF
--- a/pando/algorithms/website.py
+++ b/pando/algorithms/website.py
@@ -144,6 +144,7 @@ def get_response_for_exception(website, exception):
     tb = traceback.format_exc()
     if isinstance(exception, Response):
         response = exception
+        response.set_whence_raised()
     elif isinstance(exception, NotFound):
         response = Response(404)
     elif isinstance(exception, NegotiationFailure):
@@ -206,6 +207,7 @@ def delegate_error_to_simplate(website, state, response, request=None, resource=
 def log_traceback_for_exception(website, exception):
     if isinstance(exception, Response):
         response = exception
+        response.set_whence_raised()
         if response.code < 500:
             return {'response': response, 'exception': None}
     else:
@@ -244,7 +246,7 @@ def log_result_of_request(website, request=None, dispatch_result=None, response=
         status = "(no response available)"
     else:
         status = response._status_text()
-        filename, linenum = response.whence_raised()
+        filename, linenum = response.whence_raised
         if filename is not None:
             status += " (%s:%d)" % (filename, linenum)
 

--- a/pando/http/response.py
+++ b/pando/http/response.py
@@ -38,6 +38,7 @@ class Response(Exception):
     """
 
     request = None
+    whence_raised = (None, None)
 
     def __init__(self, code=200, body='', headers=None):
         """Takes an int, a string, a dict.
@@ -120,11 +121,12 @@ class Response(Exception):
             body = body.replace(b'\r\r', b'\r')
         return b'\r\n'.join([status_line, headers, b'', body])
 
-    def whence_raised(self):
-        """Return a tuple, (filename, linenum) where we were raised from.
+    def set_whence_raised(self):
+        """Sets self.whence_raised
 
-        If we're not the exception currently being handled then the return
-        value is (None, None).
+        It's a tuple, (filename, linenum) where we were raised from.
+
+        This function needs to be called from inside the `except` block.
 
         """
         tb = filepath = linenum = None
@@ -147,4 +149,4 @@ class Response(Exception):
                 linenum = frame.f_lineno
         finally:
             del tb  # http://docs.python.org/2/library/sys.html#sys.exc_info
-        return filepath, linenum
+        self.whence_raised = (filepath, linenum)

--- a/tests/test_response.py
+++ b/tests/test_response.py
@@ -3,6 +3,7 @@ from __future__ import division
 from __future__ import print_function
 from __future__ import unicode_literals
 
+import os
 from pytest import raises
 
 from pando import Response
@@ -87,5 +88,5 @@ def test_set_whence_raised_works():
     except Response as r:
         assert r.whence_raised == (None, None)
         r.set_whence_raised()
-        assert r.whence_raised[0] == 'tests/test_response.py'
+        assert r.whence_raised[0] == 'tests' + os.sep + 'test_response.py'
         assert isinstance(r.whence_raised[1], int)

--- a/tests/test_response.py
+++ b/tests/test_response.py
@@ -80,3 +80,12 @@ def test_response_cookie():
         assert headers[0][0] == str('Set-Cookie')
         assert headers[0][1].startswith(str('foo=bar'))
     response.to_wsgi({}, start_response, 'utf8')
+
+def test_set_whence_raised_works():
+    try:
+        raise Response(200)
+    except Response as r:
+        assert r.whence_raised == (None, None)
+        r.set_whence_raised()
+        assert r.whence_raised[0] == 'tests/test_response.py'
+        assert isinstance(r.whence_raised[1], int)


### PR DESCRIPTION
This PR aims to close #282. We already log the full traceback, so why fix `whence_raised`? And if we're not going to fix it, then why keep it?