### PR TITLE
Invert type hierarchy of request.line

### DIFF
--- a/docs/conf.py
+++ b/docs/conf.py
@@ -46,6 +46,9 @@ exclude_patterns = []
 # The name of the Pygments (syntax highlighting) style to use.
 pygments_style = 'sphinx'
 
+# Get rid of the need for `py:` prefixes everywhere.
+primary_domain = 'py'
+
 
 # -- Autodoc options
 

--- a/docs/index.rst
+++ b/docs/index.rst
@@ -14,7 +14,7 @@ Pando's source code is on `GitHub`_, and is `MIT-licensed`_.
  Installation
 **************
 
-:py:mod:`pando` is available on `PyPI`_::
+:mod:`pando` is available on `PyPI`_::
 
     $ pip install pando
 

--- a/pando/body_parsers.py
+++ b/pando/body_parsers.py
@@ -12,7 +12,7 @@ A body parser has the signature::
    def name(raw, headers):
 
 where ``raw`` is the raw bytestring to be parsed, and ``headers`` is the
-:py:class:`.Headers` mapping of the supplied headers.
+:class:`.Headers` mapping of the supplied headers.
 """
 
 import cgi
@@ -79,8 +79,8 @@ def parse_body(raw, headers, parsers):
     """Parses the ``raw`` bytestring using the ``headers`` to determine which of
     the ``parsers`` should be used.
 
-    Raises :py:exc:`.UnknownBodyType` if the HTTP ``Content-Type`` isn't recognized,
-    and :py:exc:`.MalformedBody` if the parser raises a :py:exc:`ValueError`.
+    Raises :exc:`.UnknownBodyType` if the HTTP ``Content-Type`` isn't recognized,
+    and :exc:`.MalformedBody` if the parser raises a :exc:`ValueError`.
 
     """
 

--- a/pando/exceptions.py
+++ b/pando/exceptions.py
@@ -14,7 +14,7 @@ from . import Response
 
 class CRLFInjection(Response):
     """
-    A 400 :py:class:`.Response` (per `#249`_) raised if there's a suspected CRLF
+    A 400 :class:`.Response` (per `#249`_) raised if there's a suspected CRLF
     Injection attack in the headers.
 
     .. _#249: https://github.com/AspenWeb/pando.py/issues/249
@@ -25,7 +25,7 @@ class CRLFInjection(Response):
 
 class MalformedHeader(Response):
     """
-    A 400 :py:class:`.Response` (per `RFC7230 section 3.2.4`_) raised if there's
+    A 400 :class:`.Response` (per `RFC7230 section 3.2.4`_) raised if there's
     no ``:`` in a header field, or if there's leading or trailing whitespace in
     the key part of a header field.
 
@@ -37,7 +37,7 @@ class MalformedHeader(Response):
 
 class MalformedBody(Response):
     """
-    A 400 :py:class:`.Response` raised if parsing the body of a POST request fails.
+    A 400 :class:`.Response` raised if parsing the body of a POST request fails.
     """
     def __init__(self, msg):
         Response.__init__(self, code=400, body="Malformed body: %s" % msg)
@@ -45,7 +45,7 @@ class MalformedBody(Response):
 
 class UnknownBodyType(Response):
     """
-    A 415 :py:class:`.Response` raised if the ``Content-Type`` of the body of a
+    A 415 :class:`.Response` raised if the ``Content-Type`` of the body of a
     POST request doesn't have a ``body_parser`` registered for it.
     """
     def __init__(self, ctype):
@@ -54,7 +54,7 @@ class UnknownBodyType(Response):
 
 class BadLocation(Response):
     """
-    A 500 :py:class:`.Response` raised if an invalid redirect is attempted.
+    A 500 :class:`.Response` raised if an invalid redirect is attempted.
     """
     def __init__(self, msg):
         Response.__init__(self, code=500, body="Bad redirect location: %s" % msg)

--- a/pando/http/mapping.py
+++ b/pando/http/mapping.py
@@ -13,7 +13,7 @@ from aspen.http.mapping import Mapping as _Mapping
 class Mapping(_Mapping):
 
     def keyerror(self, name):
-        """Raises a 400 :py:class:`~pando.http.response.Response`.
+        """Raises a 400 :class:`~pando.http.response.Response`.
         """
         from .response import Response
         raise Response(400, "Missing key: %s" % repr(name))

--- a/pando/http/request.py
+++ b/pando/http/request.py
@@ -224,7 +224,7 @@ class Request(str):
 
     @property
     def method(self):
-        return self.line.method
+        return self.line.method.as_text
 
     @property
     def path(self):
@@ -304,7 +304,7 @@ class Request(str):
 
         """
         methods = [x.upper() for x in methods]
-        if self.line.method not in methods:
+        if self.method not in methods:
             raise Response(405, headers={
                 b'Allow': b', '.join(m.encode('ascii') for m in methods)
             })
@@ -338,7 +338,6 @@ class Line(bytes):
         return obj
 
 
-
 # Request -> Method
 # -----------------
 
@@ -354,11 +353,9 @@ CHARS_ALLOWED_IN_METHOD = set(
     string.ascii_letters + string.digits + "!#$%&'*+-.^_`|~"
 )
 
-class Method(text_type):
+class Method(bytes):
     """Represent the HTTP method in the first line of an HTTP Request message.
     """
-
-    __slots__ = ['raw']
 
     def __new__(cls, raw):
         """Creates a new Method object.
@@ -387,8 +384,8 @@ class Method(text_type):
             if any(char not in CHARS_ALLOWED_IN_METHOD for char in decoded):
                 raise Response(400, "Your request method violates RFC 7230: %s" % decoded)
 
-        obj = super(Method, cls).__new__(cls, decoded)
-        obj.raw = raw
+        obj = super(Method, cls).__new__(cls, raw)
+        obj.as_text = decoded
         return obj
 
 

--- a/pando/http/request.py
+++ b/pando/http/request.py
@@ -333,7 +333,7 @@ class Method(bytes):
     def __new__(cls, raw):
         """Creates a new Method object.
 
-        Raises a 400 :py:class:`.Response` if the given bytestring is not a
+        Raises a 400 :class:`.Response` if the given bytestring is not a
         valid HTTP method, per RFC7230 section 3.1.1:
 
             Recipients of an invalid request-line SHOULD respond with either a
@@ -375,7 +375,7 @@ class URI(text_type):
         """Creates a URI object from a raw bytestring.
 
         We require that ``raw`` be decodable with ASCII, if it isn't a
-        :py:exc:`UnicodeDecodeError` is raised.
+        :exc:`UnicodeDecodeError` is raised.
         """
         decoded = raw.decode('ASCII')
         parts = decoded.split('?', 1)
@@ -413,8 +413,8 @@ version_re = re.compile(br'^HTTP/([0-9])\.([0-9])$')
 class Version(bytes):
     """Holds the version from the HTTP status line, e.g. HTTP/1.1.
 
-    Accessing the :py:attr:`info`, :py:attr:`major`, or :py:attr:`minor`
-    attribute will raise a 400 :py:class:`.Response` if the version is invalid.
+    Accessing the :attr:`info`, :attr:`major`, or :attr:`minor`
+    attribute will raise a 400 :class:`.Response` if the version is invalid.
 
     `RFC7230 section 2.6 <https://tools.ietf.org/html/rfc7230#section-2.6>`_::
 

--- a/pando/http/request.py
+++ b/pando/http/request.py
@@ -122,33 +122,6 @@ def kick_against_goad(environ):
     return method, uri, server, version, headers, body
 
 
-# *WithRaw
-# ========
-# A few parts of the Request object model use these generic objects.
-
-class IntWithRaw(int):
-    """Generic subclass of int to store the underlying raw bytestring.
-    """
-
-    def __new__(cls, i):
-        if i is None:
-            i = 0
-        obj = super(IntWithRaw, cls).__new__(cls, i)
-        obj.raw = str(i)
-        return obj
-
-class UnicodeWithRaw(text_type):
-    """Generic subclass of unicode to store the underlying raw bytestring.
-    """
-
-    __slots__ = ['raw']
-
-    def __new__(cls, raw, encoding='UTF-8'):
-        obj = super(UnicodeWithRaw, cls).__new__(cls, raw.decode(encoding))
-        obj.raw = raw
-        return obj
-
-
 ###########
 # Request #
 ###########
@@ -495,7 +468,10 @@ class Headers(BaseHeaders):
         # we prefer X-Forwarded-For if that is available.
 
         host = self.get(b'X-Forwarded-Host', self[b'Host']) # KeyError raises 400
-        self.host = UnicodeWithRaw(host, encoding='idna')
+        try:
+            self.host = host.decode('idna')
+        except UnicodeError:
+            self.host = ''
 
 
         # Scheme

--- a/pando/state_chain.py
+++ b/pando/state_chain.py
@@ -68,7 +68,7 @@ def request_available():
 
 def raise_200_for_OPTIONS(request):
     """A hook to return 200 to an 'OPTIONS \*' request"""
-    if request.line.method == "OPTIONS" and request.line.uri == "*":
+    if request.line.method == b"OPTIONS" and request.line.uri == "*":
         raise Response(200)
 
 

--- a/pando/state_chain.py
+++ b/pando/state_chain.py
@@ -9,7 +9,7 @@ processing. The actual parsing is done by `Algorithm.from_dotted_name()
 <http://algorithm-py.readthedocs.org/en/latest/#algorithm.Algorithm.from_dotted_name>`_.
 
 Dependencies are injected as specified in each function definition. Each function
-should return :py:obj:`None`, or a dictionary that will be used to update the
+should return :obj:`None`, or a dictionary that will be used to update the
 state in the calling routine.
 
 It's important that function names remain relatively stable over time, as

--- a/pando/state_chain.py
+++ b/pando/state_chain.py
@@ -230,7 +230,7 @@ def log_result_of_request(website, request=None, dispatch_result=None, response=
                 fspath = '.' + fspath
         else:
             fspath = '...' + fspath[-21:]
-        msg = "%-24s %s" % (request.line.uri.path.raw, fspath)
+        msg = "%-24s %s" % (request.line.uri.path.decoded, fspath)
 
 
     # Where was response raised from?

--- a/pando/website.py
+++ b/pando/website.py
@@ -155,7 +155,7 @@ class Website(object):
 
         if actual != self.base_url:
             url = self.base_url
-            if request.line.method in ('GET', 'HEAD', 'OPTIONS', 'TRACE'):
+            if request.method in ('GET', 'HEAD', 'OPTIONS', 'TRACE'):
                 # Redirect to a particular path for idempotent methods.
                 url += request.line.uri.path.raw
                 if request.line.uri.querystring:

--- a/pando/website.py
+++ b/pando/website.py
@@ -157,9 +157,9 @@ class Website(object):
             url = self.base_url
             if request.method in ('GET', 'HEAD', 'OPTIONS', 'TRACE'):
                 # Redirect to a particular path for idempotent methods.
-                url += request.line.uri.path.raw
+                url += request.line.uri.path.decoded
                 if request.line.uri.querystring:
-                    url += '?' + request.line.uri.querystring.raw
+                    url += '?' + request.line.uri.querystring.decoded
             else:
                 # For non-idempotent methods, redirect to homepage.
                 url += '/'

--- a/pando/website.py
+++ b/pando/website.py
@@ -47,7 +47,7 @@ class Website(object):
     def __init__(self, **kwargs):
         """Takes configuration in kwargs.
         """
-        #: An Aspen :py:class:`~aspen.request_processor.RequestProcessor` instance.
+        #: An Aspen :class:`~aspen.request_processor.RequestProcessor` instance.
         self.request_processor = RequestProcessor(**kwargs)
 
         pando_chain = Algorithm.from_dotted_name('pando.state_chain')
@@ -55,7 +55,7 @@ class Website(object):
             getattr(f, 'placeholder_for', f) for f in pando_chain.functions
         ]
         #: The chain of functions used to process an HTTP request, imported from
-        #: :py:mod:`pando.state_chain`.
+        #: :mod:`pando.state_chain`.
         self.state_chain = pando_chain
 
         # copy aspen's config variables, for backward compatibility
@@ -78,7 +78,7 @@ class Website(object):
         }
 
     def __call__(self, environ, start_response):
-        """Alias of :py:meth:`wsgi_app`.
+        """Alias of :meth:`wsgi_app`.
         """
         return self.wsgi_app(environ, start_response)
 
@@ -181,7 +181,7 @@ class Website(object):
     def ours_or_theirs(self, filename):
         """Given a filename, return a filepath or ``None``.
 
-        It looks for the file in :py:attr:`self.project_root`, then in Pando's
+        It looks for the file in :attr:`self.project_root`, then in Pando's
         default files directory. ``None`` is returned if the file is not found
         in either location.
         """

--- a/pando/wsgi.py
+++ b/pando/wsgi.py
@@ -17,7 +17,7 @@ from __future__ import unicode_literals
 
 from .website import Website
 
-#: This is the WSGI callable, an instance of :py:class:`.Website`.
+#: This is the WSGI callable, an instance of :class:`.Website`.
 website = Website()
 
 #: Alias of ``website``. A number of WSGI servers look for this name by default,

--- a/tests/test_request.py
+++ b/tests/test_request.py
@@ -30,7 +30,7 @@ def test_request_line_version_defaults_to_HTTP_1_1(harness):
 
 def test_allow_default_method_is_GET(harness):
     request = harness.make_request()
-    expected = 'GET'
+    expected = b'GET'
     actual = request.line.method
     assert actual == expected
 
@@ -54,14 +54,14 @@ def test_allow_can_handle_lowercase(harness):
 
 def test_methods_start_with_GET(harness):
     request = harness.make_request()
-    expected = "GET"
+    expected = b"GET"
     actual = request.line.method
     assert actual == expected
 
 def test_methods_changing_changes(harness):
     request = harness.make_request()
-    request.line.method = 'POST'
-    expected = "POST"
+    request.line.method = b'POST'
+    expected = b"POST"
     actual = request.line.method
     assert actual == expected
 

--- a/tests/test_request.py
+++ b/tests/test_request.py
@@ -13,12 +13,6 @@ from pando.http.baseheaders import BaseHeaders
 from pando.exceptions import MalformedHeader
 
 
-def test_request_line_raw_works(harness):
-    request = harness.make_request()
-    actual = request.line.raw
-    expected = b"GET / HTTP/1.1"
-    assert actual == expected
-
 def test_raw_is_raw():
     request = Request()
     expected = "GET / HTTP/1.1\r\nHost: localhost\r\n\r\n"
@@ -32,12 +26,6 @@ def test_request_line_version_defaults_to_HTTP_1_1(harness):
     request = harness.make_request()
     actual = request.line.version.info
     expected = (1, 1)
-    assert actual == expected
-
-def test_request_line_version_raw_works(harness):
-    request = harness.make_request()
-    actual = request.line.version.raw
-    expected = b"HTTP/1.1"
     assert actual == expected
 
 def test_allow_default_method_is_GET(harness):

--- a/tests/test_request.py
+++ b/tests/test_request.py
@@ -128,7 +128,7 @@ def test_method_alias_is_read_only(harness):
 
 def test_path_alias_is_readable(harness):
     request = harness.make_request()
-    assert request.path.raw == '/'
+    assert request.path.decoded == '/'
 
 def test_path_alias_is_read_only(harness):
     request = harness.make_request()

--- a/tests/test_request_line.py
+++ b/tests/test_request_line.py
@@ -29,14 +29,14 @@ def test_line_has_method():
 
 def test_line_has_uri():
     line = Line(b"GET", b"/", b"HTTP/0.9")
-    assert line.uri == "/"
+    assert line.uri == b"/"
 
 def test_line_has_version():
     line = Line(b"GET", b"/", b"HTTP/0.9")
     assert line.version == b"HTTP/0.9"
 
-def test_line_chokes_on_non_ASCII_in_uri():
-    raises(UnicodeDecodeError, Line, b"GET", byte(128), b"HTTP/1.1")
+def test_line_raises_404_on_non_ASCII_in_uri():
+    assert raises(Response, Line, b"GET", byte(128), b"HTTP/1.1").value.code == 400
 
 
 # Method
@@ -147,9 +147,7 @@ def test_method_no_chr_125(): the400(125) # }
 
 def test_uri_works_at_all():
     uri = URI(b"/")
-    expected = "/"
-    actual = uri
-    assert actual == expected
+    assert uri == b'/'
 
 
 def test_uri_sets_path():
@@ -161,19 +159,19 @@ def test_uri_sets_querystring():
     assert uri.querystring.decoded == "buz=bloo", uri.querystring.decoded
 
 
-def test_uri_path_is_Mapping():
+def test_uri_path_mapping():
     uri = URI(b"/baz.html?buz=bloo")
-    assert isinstance(uri.path, Mapping)
+    assert isinstance(uri.path.mapping, Mapping)
 
-def test_uri_querystring_is_Mapping():
+def test_uri_querystring_mapping():
     uri = URI(b"/baz.html?buz=bloo")
-    assert isinstance(uri.querystring, Mapping)
+    assert isinstance(uri.querystring.mapping, Mapping)
 
 
 def test_uri_normal_case_is_normal():
     uri = URI(b"/baz.html?buz=bloo")
-    assert uri.path == Path("/baz.html")
-    assert uri.querystring == Querystring("buz=bloo")
+    assert uri.path == Path(b"/baz.html")
+    assert uri.querystring == Querystring(b"buz=bloo")
 
 
 

--- a/tests/test_request_line.py
+++ b/tests/test_request_line.py
@@ -21,7 +21,7 @@ def byte(i):
 
 def test_line_works():
     line = Line(b"GET", b"/", b"HTTP/0.9")
-    assert line == "GET / HTTP/0.9"
+    assert line == b"GET / HTTP/0.9"
 
 def test_line_has_method():
     line = Line(b"GET", b"/", b"HTTP/0.9")
@@ -33,7 +33,7 @@ def test_line_has_uri():
 
 def test_line_has_version():
     line = Line(b"GET", b"/", b"HTTP/0.9")
-    assert line.version == "HTTP/0.9"
+    assert line.version == b"HTTP/0.9"
 
 def test_line_chokes_on_non_ASCII_in_uri():
     raises(UnicodeDecodeError, Line, b"GET", byte(128), b"HTTP/1.1")
@@ -190,30 +190,30 @@ def test_uri_normal_case_is_normal():
 
 def test_version_can_be_HTTP_0_9():
     actual = Version(b"HTTP/0.9")
-    expected = "HTTP/0.9"
+    expected = b"HTTP/0.9"
     assert actual == expected
 
 def test_version_can_be_HTTP_1_0():
     actual = Version(b"HTTP/1.0")
-    expected = "HTTP/1.0"
+    expected = b"HTTP/1.0"
     assert actual == expected
 
 def test_version_can_be_HTTP_1_1():
     actual = Version(b"HTTP/1.1")
-    expected = "HTTP/1.1"
+    expected = b"HTTP/1.1"
     assert actual == expected
 
-def test_version_cant_be_HTTP_1_2():
-    assert raises(Response, Version, b"HTTP/1.2").value.code == 505
+def test_version_can_be_HTTP_1_2():
+    assert Version(b"HTTP/1.2").info == (1, 2)
 
 def test_version_cant_be_junk():
-    assert raises(Response, Version, b"http flah flah").value.code == 400
+    assert raises(Response, lambda: Version(b"http flah flah").info).value.code == 400
 
 def test_version_cant_even_be_lowercase():
-    assert raises(Response, Version, b"http/1.1").value.code == 400
+    assert raises(Response, lambda: Version(b"http/1.1").info).value.code == 400
 
 def test_version_with_garbage_is_safe():
-    r = raises(Response, Version, b"HTTP\xef/1.1").value
+    r = raises(Response, lambda: Version(b"HTTP\xef/1.1").info).value
     assert r.code == 400, r.code
     assert r.body == "Bad HTTP version: HTTP\\xef/1.1.", r.body
 
@@ -235,8 +235,6 @@ def test_version_info_is_tuple():
     actual = version.info
     assert actual == expected
 
-def test_version_raw_is_bytestring():
+def test_version_is_bytestring():
     version = Version(b"HTTP/0.9")
-    expected = bytes
-    actual = version.raw.__class__
-    assert actual is expected
+    assert isinstance(version, bytes)

--- a/tests/test_request_line.py
+++ b/tests/test_request_line.py
@@ -25,7 +25,7 @@ def test_line_works():
 
 def test_line_has_method():
     line = Line(b"GET", b"/", b"HTTP/0.9")
-    assert line.method == "GET"
+    assert line.method == b"GET"
 
 def test_line_has_uri():
     line = Line(b"GET", b"/", b"HTTP/0.9")
@@ -44,46 +44,42 @@ def test_line_chokes_on_non_ASCII_in_uri():
 
 def test_method_works():
     method = Method(b"GET")
-    assert method == "GET"
+    assert method == b"GET"
 
-def test_method_is_unicode_subclass():
+def test_method_is_bytes_subclass():
     method = Method(b"GET")
-    assert issubclass(method.__class__, text_type)
+    assert issubclass(method.__class__, bytes)
 
-def test_method_is_unicode_instance():
+def test_method_is_bytes_instance():
     method = Method(b"GET")
-    assert isinstance(method, text_type)
+    assert isinstance(method, bytes)
 
-def test_method_raw_works():
+def test_method_as_text_works():
     method = Method(b"GET")
-    assert method.raw == b"GET"
+    assert method.as_text == "GET"
 
-def test_method_raw_is_bytestring():
+def test_method_as_text_is_text():
     method = Method(b"GET")
-    assert isinstance(method.raw, bytes)
+    assert isinstance(method.as_text, text_type)
 
-def test_method_cant_have_more_attributes():
-    method = Method(b"GET")
-    raises(AttributeError, setattr, method, "foo", "bar")
-
-def test_method_can_be_OPTIONS(): assert Method(b"OPTIONS") == "OPTIONS"
-def test_method_can_be_GET():     assert Method(b"GET")     == "GET"
-def test_method_can_be_HEAD():    assert Method(b"HEAD")    == "HEAD"
-def test_method_can_be_POST():    assert Method(b"POST")    == "POST"
-def test_method_can_be_PUT():     assert Method(b"PUT")     == "PUT"
-def test_method_can_be_DELETE():  assert Method(b"DELETE")  == "DELETE"
-def test_method_can_be_TRACE():   assert Method(b"TRACE")   == "TRACE"
-def test_method_can_be_CONNECT(): assert Method(b"CONNECT") == "CONNECT"
+def test_method_can_be_OPTIONS(): assert Method(b"OPTIONS") == b"OPTIONS"
+def test_method_can_be_GET():     assert Method(b"GET")     == b"GET"
+def test_method_can_be_HEAD():    assert Method(b"HEAD")    == b"HEAD"
+def test_method_can_be_POST():    assert Method(b"POST")    == b"POST"
+def test_method_can_be_PUT():     assert Method(b"PUT")     == b"PUT"
+def test_method_can_be_DELETE():  assert Method(b"DELETE")  == b"DELETE"
+def test_method_can_be_TRACE():   assert Method(b"TRACE")   == b"TRACE"
+def test_method_can_be_CONNECT(): assert Method(b"CONNECT") == b"CONNECT"
 
 def test_method_can_be_big():
     big = b"0123456789ABCDEFGHIJKLMNOPQRSTUVWXYZabcdefghijklmnopqrstuvwxyz--"
-    assert Method(big).raw == big
+    assert Method(big) == big
 
 def test_method_cant_be_non_ASCII():
     assert raises(Response, Method, b"\x80").value.code == 400
 
 def test_method_can_be_valid_perl():
-    assert Method(b"!#$%&'*+-.^_`|~") == "!#$%&'*+-.^_`|~"
+    assert Method(b"!#$%&'*+-.^_`|~") == b"!#$%&'*+-.^_`|~"
 
 def the400(i):
     assert raises(Response, Method, byte(i)).value.code == 400
@@ -125,7 +121,7 @@ def test_method_no_chr_29(): the400(29)
 def test_method_no_chr_30(): the400(30)
 def test_method_no_chr_31(): the400(31)
 def test_method_no_chr_32(): the400(32) # space
-def test_method_no_chr_33(): assert Method(byte(33)) == '!'
+def test_method_no_chr_33(): assert Method(byte(33)) == b'!'
 
 def test_method_no_chr_40(): the400(40) # (
 def test_method_no_chr_41(): the400(41) # )

--- a/tests/test_request_line.py
+++ b/tests/test_request_line.py
@@ -79,75 +79,71 @@ def test_method_can_be_big():
     big = b"0123456789ABCDEFGHIJKLMNOPQRSTUVWXYZabcdefghijklmnopqrstuvwxyz--"
     assert Method(big).raw == big
 
-def test_method_we_cap_it_at_64_bytes_just_cause____I_mean___come_on___right():
-    big = b"0123456789ABCDEFGHIJKLMNOPQRSTUVWXYZabcdefghijklmnopqrstuvwxyz--!"
-    assert raises(Response, Method, big).value.code == 501
-
 def test_method_cant_be_non_ASCII():
-    assert raises(Response, Method, b"\x80").value.code == 501
+    assert raises(Response, Method, b"\x80").value.code == 400
 
 def test_method_can_be_valid_perl():
     assert Method(b"!#$%&'*+-.^_`|~") == "!#$%&'*+-.^_`|~"
 
-def the501(i):
-    assert raises(Response, Method, byte(i)).value.code == 501
+def the400(i):
+    assert raises(Response, Method, byte(i)).value.code == 400
 
 # 0-31
-def test_method_no_chr_0(): the501(0)
-def test_method_no_chr_1(): the501(1)
-def test_method_no_chr_2(): the501(2)
-def test_method_no_chr_3(): the501(3)
-def test_method_no_chr_4(): the501(4)
-def test_method_no_chr_5(): the501(5)
-def test_method_no_chr_6(): the501(6)
-def test_method_no_chr_7(): the501(7)
-def test_method_no_chr_8(): the501(8)
-def test_method_no_chr_9(): the501(9) # HT
+def test_method_no_chr_0(): the400(0)
+def test_method_no_chr_1(): the400(1)
+def test_method_no_chr_2(): the400(2)
+def test_method_no_chr_3(): the400(3)
+def test_method_no_chr_4(): the400(4)
+def test_method_no_chr_5(): the400(5)
+def test_method_no_chr_6(): the400(6)
+def test_method_no_chr_7(): the400(7)
+def test_method_no_chr_8(): the400(8)
+def test_method_no_chr_9(): the400(9) # HT
 
-def test_method_no_chr_10(): the501(10)
-def test_method_no_chr_11(): the501(11)
-def test_method_no_chr_12(): the501(12)
-def test_method_no_chr_13(): the501(13)
-def test_method_no_chr_14(): the501(14)
-def test_method_no_chr_15(): the501(15)
-def test_method_no_chr_16(): the501(16)
-def test_method_no_chr_17(): the501(17)
-def test_method_no_chr_18(): the501(18)
-def test_method_no_chr_19(): the501(19)
+def test_method_no_chr_10(): the400(10)
+def test_method_no_chr_11(): the400(11)
+def test_method_no_chr_12(): the400(12)
+def test_method_no_chr_13(): the400(13)
+def test_method_no_chr_14(): the400(14)
+def test_method_no_chr_15(): the400(15)
+def test_method_no_chr_16(): the400(16)
+def test_method_no_chr_17(): the400(17)
+def test_method_no_chr_18(): the400(18)
+def test_method_no_chr_19(): the400(19)
 
-def test_method_no_chr_20(): the501(20)
-def test_method_no_chr_21(): the501(21)
-def test_method_no_chr_22(): the501(22)
-def test_method_no_chr_23(): the501(23)
-def test_method_no_chr_24(): the501(24)
-def test_method_no_chr_25(): the501(25)
-def test_method_no_chr_26(): the501(26)
-def test_method_no_chr_27(): the501(27)
-def test_method_no_chr_28(): the501(28)
-def test_method_no_chr_29(): the501(29)
+def test_method_no_chr_20(): the400(20)
+def test_method_no_chr_21(): the400(21)
+def test_method_no_chr_22(): the400(22)
+def test_method_no_chr_23(): the400(23)
+def test_method_no_chr_24(): the400(24)
+def test_method_no_chr_25(): the400(25)
+def test_method_no_chr_26(): the400(26)
+def test_method_no_chr_27(): the400(27)
+def test_method_no_chr_28(): the400(28)
+def test_method_no_chr_29(): the400(29)
 
-def test_method_no_chr_30(): the501(30)
-def test_method_no_chr_31(): the501(31)
-def test_method_no_chr_32(): the501(32) # space
+def test_method_no_chr_30(): the400(30)
+def test_method_no_chr_31(): the400(31)
+def test_method_no_chr_32(): the400(32) # space
 def test_method_no_chr_33(): assert Method(byte(33)) == '!'
 
-def test_method_no_chr_40(): the501(40) # (
-def test_method_no_chr_41(): the501(41) # )
-def test_method_no_chr_60(): the501(60) # <
-def test_method_no_chr_62(): the501(62) # >
-def test_method_no_chr_64(): the501(64) # @
-def test_method_no_chr_44(): the501(44) # ,
-def test_method_no_chr_59(): the501(59) # ;
-def test_method_no_chr_58(): the501(58) # :
-def test_method_no_chr_92(): the501(92) # \
-def test_method_no_chr_34(): the501(34) # "
-def test_method_no_chr_47(): the501(47) # /
-def test_method_no_chr_91(): the501(91) # [
-def test_method_no_chr_93(): the501(93) # ]
-def test_method_no_chr_63(): the501(63) # ?
-def test_method_no_chr_61(): the501(61) # =
-def test_method_no_chr_123(): the501(123) # {
-def test_method_no_chr_125(): the501(125) # }
+def test_method_no_chr_40(): the400(40) # (
+def test_method_no_chr_41(): the400(41) # )
+def test_method_no_chr_60(): the400(60) # <
+def test_method_no_chr_62(): the400(62) # >
+def test_method_no_chr_64(): the400(64) # @
+def test_method_no_chr_44(): the400(44) # ,
+def test_method_no_chr_59(): the400(59) # ;
+def test_method_no_chr_58(): the400(58) # :
+def test_method_no_chr_92(): the400(92) # \
+def test_method_no_chr_34(): the400(34) # "
+def test_method_no_chr_47(): the400(47) # /
+def test_method_no_chr_91(): the400(91) # [
+def test_method_no_chr_93(): the400(93) # ]
+def test_method_no_chr_63(): the400(63) # ?
+def test_method_no_chr_61(): the400(61) # =
+def test_method_no_chr_123(): the400(123) # {
+def test_method_no_chr_125(): the400(125) # }
 
 
 # URI


### PR DESCRIPTION
This PR will close #222.

Note that it also modifies the handling of HTTP methods: it removes the length limit of 64 and changes the response code from 501 to 400 when the method is invalid.