### PR TITLE
Fix request parsing

### DIFF
--- a/pando/http/request.py
+++ b/pando/http/request.py
@@ -33,12 +33,12 @@ import string
 import sys
 
 from six import PY2
-import six.moves.urllib.parse as urlparse
 
 from aspen.http.request import Path as _Path, Querystring as _Querystring
 
 from .. import Response
 from ..exceptions import MalformedBody, UnknownBodyType
+from ..urlparse import quote, quote_plus
 from ..utils import try_encode
 from .baseheaders import BaseHeaders
 from .mapping import Mapping
@@ -80,7 +80,7 @@ def make_franken_uri(path, qs):
 
             # Some servers (gevent) clobber %2F inside of paths, such
             # that we see /foo%2Fbar/ as /foo/bar/. The %2F is lost to us.
-            parts = [urlparse.quote(x) for x in quoted_slash_re.split(path)]
+            parts = [quote(x) for x in quoted_slash_re.split(path)]
             path = b"%2F".join(parts)
 
     if qs:
@@ -90,7 +90,7 @@ def make_franken_uri(path, qs):
             # Cross our fingers and hope we have UTF-8 bytes from MSIE. Let's
             # perform the percent-encoding that we would expect MSIE to have
             # done for us.
-            qs = urlparse.quote_plus(qs)
+            qs = quote_plus(qs)
         qs = b'?' + qs
 
     return path + qs

--- a/pando/urlparse.py
+++ b/pando/urlparse.py
@@ -1,0 +1,27 @@
+from __future__ import absolute_import, division, print_function, unicode_literals
+
+try:
+    from urllib.parse import quote, quote_plus
+except ImportError:
+    from urllib import quote as _quote, quote_plus as _quote_plus
+
+    # Monkey-patch urllib to counter the effects of unicode_literals
+    import urllib
+    urllib.always_safe = urllib.always_safe.encode('ascii')
+    urllib._safe_quoters.clear()
+
+    def quote(string, safe=b'/'):
+        if not isinstance(safe, bytes):
+            safe = safe.encode('ascii', 'ignore')
+        if not isinstance(string, bytes):
+            string = string.encode('utf8')
+        return _quote(string, safe)
+
+    def quote_plus(string, safe=b''):
+        if not isinstance(safe, bytes):
+            safe = safe.encode('ascii', 'ignore')
+        if not isinstance(string, bytes):
+            string = string.encode('utf8')
+        return _quote_plus(string, safe)
+
+__all__ = [quote, quote_plus]

--- a/pando/website.py
+++ b/pando/website.py
@@ -11,8 +11,6 @@ import datetime
 import os
 import string
 
-from six.moves.urllib.parse import quote
-
 from algorithm import Algorithm
 from aspen.configuration import configure, parse
 from aspen.request_processor import KNOBS as ASPEN_KNOBS, RequestProcessor
@@ -20,6 +18,7 @@ from aspen.simplates.simplate import Simplate
 
 from . import body_parsers
 from .http.response import Response
+from .urlparse import quote
 from .utils import maybe_encode, to_rfc822, utc
 from .exceptions import BadLocation
 
@@ -124,7 +123,7 @@ class Website(object):
         response = response if response else Response()
         response.code = code if code else (301 if permanent else 302)
         base_url = base_url if base_url is not None else self.base_url
-        location = quote(maybe_encode(location, 'utf8'), string.punctuation)
+        location = quote(location, string.punctuation)
         if not location.startswith(base_url):
             newloc = base_url + location
             if not location.startswith('/'):


### PR DESCRIPTION
This branch fixes two issues in the request parsing:

- some unicode errors weren't caught and re-raised as `Response(400)`
- a request with a querystring containing raw (not percent-encoded) non-ASCII characters triggered such an error when using python 2, because the stdlib is flawed and needs to be monkey-patched