### PR TITLE
Switch from `algorithm` to `state_chain`

### DIFF
--- a/pando/state_chain.py
+++ b/pando/state_chain.py
@@ -5,8 +5,8 @@
 These functions comprise the request processing functionality of Pando.
 
 The order of functions in this module defines Pando's state chain for request
-processing. The actual parsing is done by `Algorithm.from_dotted_name()
-<http://algorithm-py.readthedocs.org/en/latest/#algorithm.Algorithm.from_dotted_name>`_.
+processing. The actual parsing is done by `StateChain.from_dotted_name()
+<https://state-chain-py.readthedocs.io/en/latest/#state_chain.StateChain.from_dotted_name>`_.
 
 Dependencies are injected as specified in each function definition. Each function
 should return :obj:`None`, or a dictionary that will be used to update the

--- a/pando/state_chain.py
+++ b/pando/state_chain.py
@@ -58,7 +58,7 @@ def request_available():
 
 
 def raise_200_for_OPTIONS(request):
-    """A hook to return 200 to an 'OPTIONS \*' request"""
+    r"""A hook to return 200 to an 'OPTIONS \*' request"""
     if request.line.method == b"OPTIONS" and request.line.uri == b"*":
         raise Response(200)
 

--- a/pando/website.py
+++ b/pando/website.py
@@ -11,10 +11,10 @@ import datetime
 import os
 import string
 
-from algorithm import Algorithm
 from aspen.configuration import configure, parse
 from aspen.request_processor import KNOBS as ASPEN_KNOBS, RequestProcessor
 from aspen.simplates.simplate import Simplate
+from state_chain import StateChain
 
 from . import body_parsers
 from .http.response import Response
@@ -40,7 +40,7 @@ class Website(object):
 
     This object holds configuration information, and how to handle HTTP
     requests (per WSGI). It is available to user-developers inside of their
-    simplates and algorithm functions.
+    simplates and state chain functions.
 
     """
 
@@ -50,7 +50,7 @@ class Website(object):
         #: An Aspen :class:`~aspen.request_processor.RequestProcessor` instance.
         self.request_processor = RequestProcessor(**kwargs)
 
-        pando_chain = Algorithm.from_dotted_name('pando.state_chain')
+        pando_chain = StateChain.from_dotted_name('pando.state_chain')
         pando_chain.functions = [
             getattr(f, 'placeholder_for', f) for f in pando_chain.functions
         ]

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,7 +1,7 @@
 python-mimeparse>=0.1.4
 first>=2.0.1
-algorithm>=1.2.0
+state-chain>=1.3.0
 filesystem_tree>=1.0.1
-dependency_injection>=1.1.0
+dependency_injection>=1.2.0
 aspen==1.0rc3
 six

--- a/tests/test_website_flow.py
+++ b/tests/test_website_flow.py
@@ -29,7 +29,7 @@ def test_404_comes_out_404(harness):
     assert harness.client.GET(raise_immediately=False).code == 404
 
 
-def test_user_can_influence_request_context_via_algorithm_state(harness):
+def test_user_can_influence_request_context_via_chain_state(harness):
     harness.fs.www.mk(('index.html.spt', '[---]\n[---]\n%(foo)s'))
     def add_foo_to_context(request):
         return {'foo': 'bar'}


### PR DESCRIPTION
Pando's `algorithm` module was renamed to `state_chain` in #573, but it's still using the `algorithm` package.