### PR TITLE
Upgrade Aspen

### DIFF
--- a/build.py
+++ b/build.py
@@ -114,13 +114,14 @@ def clean():
 # Docs
 # ====
 
-def _sphinx_cmd(cmd, extra_pkgs=[]):
+def _sphinx_cmd(cmd, extra_args=[], extra_pkgs=[]):
     envdir = _env()
     _deps()
     run('pip', 'install', *(['sphinx', 'sphinx-rtd-theme'] + extra_pkgs))
     builddir = 'docs/_build'
     run('mkdir', '-p', builddir)
     args = ['-b', 'html', '-d', builddir + '/doctrees', 'docs', builddir + '/html']
+    args += extra_args
     run(cmd, args)
 
 def sphinx():
@@ -129,7 +130,7 @@ def sphinx():
 
 def autosphinx():
     """run sphinx-autobuild"""
-    _sphinx_cmd("sphinx-autobuild", extra_pkgs=['sphinx-autobuild'])
+    _sphinx_cmd("sphinx-autobuild", ['--watch', 'pando'], extra_pkgs=['sphinx-autobuild'])
 
 def clean_sphinx():
     """clean sphinx artifacts"""

--- a/pando/testing/harness.py
+++ b/pando/testing/harness.py
@@ -71,7 +71,7 @@ class Harness(object):
                 uripath = '/' + filepath
                 if uripath.endswith('.spt'):
                     uripath = uripath[:-len('.spt')]
-                for indexname in self.client.website.indices:
+                for indexname in self.client.website.request_processor.indices:
                     if uripath.endswith(indexname):
                         uripath = uripath[:-len(indexname)]
                         break

--- a/pando/www/autoindex.html.spt
+++ b/pando/www/autoindex.html.spt
@@ -54,7 +54,7 @@ def _get_time(stats):
 # Support the case where we are in the directory where this file actually
 # lives!
 
-fspath = dispatch_result.extra.get('autoindexdir', os.path.dirname(__file__))
+fspath = dispatch_result.canonical
 assert os.path.isdir(fspath) # sanity check
 
 urlpath = fspath[len(website.www_root):] + os.sep

--- a/requirements.txt
+++ b/requirements.txt
@@ -3,5 +3,5 @@ first>=2.0.1
 state-chain>=1.3.0
 filesystem_tree>=1.0.1
 dependency_injection>=1.2.0
-aspen==1.0rc3
+aspen==1.0rc4
 six

--- a/tests/test_request_body.py
+++ b/tests/test_request_body.py
@@ -10,13 +10,12 @@ from pytest import raises
 from pando.exceptions import MalformedBody, UnknownBodyType
 from pando.http.request import Request
 from pando.http.response import Response
-from pando.website import Website
 
 
 FORMDATA = object()
 WWWFORM = object()
 
-def make_body(raw, headers=None, content_type=WWWFORM):
+def make_body(harness, raw, headers=None, content_type=WWWFORM):
     if not isinstance(raw, bytes):
         raw = raw.encode('ascii')
     if headers is None:
@@ -26,17 +25,18 @@ def make_body(raw, headers=None, content_type=WWWFORM):
     if not b'Content-Length' in headers:
         headers[b'Content-Length'] = str(len(raw)).encode('ascii')
     headers[b'Host'] = b'Blah'
-    website = Website()
+    website = harness.client.website
     request = Request(website, body=BytesIO(raw), headers=headers)
     return request.body
 
 
-def test_body_is_unparsed_for_empty_content_type():
+def test_body_is_unparsed_for_empty_content_type(harness):
     raw = "cheese=yes"
-    raises(UnknownBodyType, make_body, raw, headers={})
+    with raises(UnknownBodyType):
+        make_body(harness, raw, headers={})
 
-def test_body_barely_works():
-    body = make_body("cheese=yes")
+def test_body_barely_works(harness):
+    body = make_body(harness, "cheese=yes")
     actual = body['cheese']
     assert actual == "yes"
 
@@ -54,38 +54,39 @@ Content-Type: text/plain
 --AaB03x--
 """.splitlines())
 
-def test_body_barely_works_for_form_data():
-    body = make_body(UPLOAD, content_type=FORMDATA)
+def test_body_barely_works_for_form_data(harness):
+    body = make_body(harness, UPLOAD, content_type=FORMDATA)
     actual = body['files'].filename
     assert actual == "file1.txt"
 
-def test_simple_values_are_simple():
-    body = make_body(UPLOAD, content_type=FORMDATA)
+def test_simple_values_are_simple(harness):
+    body = make_body(harness, UPLOAD, content_type=FORMDATA)
     actual = body['submit-name']
     assert actual == "Larry"
 
-def test_multiple_values_are_multiple():
-    body = make_body("cheese=yes&cheese=burger")
+def test_multiple_values_are_multiple(harness):
+    body = make_body(harness, "cheese=yes&cheese=burger")
     assert body.all('cheese') == ["yes", "burger"]
 
-def test_params_doesnt_break_www_form():
-    body = make_body("statement=foo"
-                    , content_type=b"application/x-www-form-urlencoded; charset=UTF-8; cheese=yummy"
-                     )
+def test_params_doesnt_break_www_form(harness):
+    body = make_body(
+        harness, "statement=foo",
+        content_type=b"application/x-www-form-urlencoded; charset=UTF-8; cheese=yummy"
+    )
     actual = body['statement']
     assert actual == "foo"
 
-def test_malformed_body_jsondata():
+def test_malformed_body_jsondata(harness):
     with raises(MalformedBody):
-        make_body("foo", content_type=b"application/json")
+        make_body(harness, "foo", content_type=b"application/json")
 
-def test_malformed_body_formdata():
+def test_malformed_body_formdata(harness):
     with raises(MalformedBody):
-        make_body("", content_type=b"multipart/form-data; boundary=\0")
+        make_body(harness, "", content_type=b"multipart/form-data; boundary=\0")
 
-def test_bad_content_length():
+def test_bad_content_length(harness):
     with raises(Response) as x:
-        make_body("{}", headers={
+        make_body(harness, "{}", headers={
             b'Content-Length': b'NaN',
             b'Content-Type': b'application/json',
         })


### PR DESCRIPTION
This branch modifies Pando to use Aspen 1.0rc4 instead of 1.0rc3. The changes in 1.0rc4 include: a new dispatcher optimized for production use, the end of storage of static files in RAM by default, and the end of support for the `ASPEN_*` environment variables. Consequently, this branch removes support for the `PANDO_*` environment variables as well.