### PR TITLE
Upgrade Aspen

### DIFF
--- a/pando/utils.py
+++ b/pando/utils.py
@@ -8,20 +8,9 @@ from __future__ import print_function
 from __future__ import unicode_literals
 
 import datetime
-from importlib import import_module
 import re
 
 from six import text_type
-
-
-def _import_from(modname):
-    def r(placeholder_func):
-        f_name = placeholder_func.__name__
-        placeholder_func.__doc__ = ".. autofunction:: %s.%s" % (modname, f_name)
-        real_func = getattr(import_module(modname), f_name)
-        placeholder_func.placeholder_for = real_func
-        return placeholder_func
-    return r
 
 
 # encoding helpers

--- a/requirements.txt
+++ b/requirements.txt
@@ -3,5 +3,5 @@ first>=2.0.1
 state-chain>=1.3.0
 filesystem_tree>=1.0.1
 dependency_injection>=1.2.0
-aspen==1.0rc4
+aspen==1.0rc5
 six


### PR DESCRIPTION
This branch modifies Pando to use Aspen 1.0rc5 instead of 1.0rc4. Changes:

- the obsolete `algorithm` package is no longer required
- the default encoding of simplates under Python 3 has been fixed (changed from ASCII to UTF-8)
- a new optimized dispatcher is used by default in development environments
- improved consistency and correctness of dispatch results
- another batch of optimizations
- official support for Python 3.7
