### PR TITLE
Request properties

### DIFF
--- a/pando/testing/client.py
+++ b/pando/testing/client.py
@@ -197,6 +197,7 @@ class Client(object):
         environ[b'REQUEST_METHOD'] = method.encode('ascii')
         environ[b'SERVER_PROTOCOL'] = b'HTTP/1.1'
         environ[b'wsgi.input'] = BytesIO(body)
+        environ[b'wsgi.url_scheme'] = 'http'
         environ[b'HTTP_CONTENT_LENGTH'] = str(len(body)).encode('ascii')
         environ.update((k.encode('ascii'), v) for k, v in kw.items())
         return environ

--- a/pando/website.py
+++ b/pando/website.py
@@ -133,24 +133,18 @@ class Website(object):
     # Base URL Canonicalization
     # =========================
 
-    def _extract_scheme(self, request):
-        return request.headers.get(b'X-Forwarded-Proto', b'http')  # Heroku
-
-    def _extract_host(self, request):
-        return request.headers[b'Host']  # will 400 if missing
-
     _canonicalize_base_url_code = 302
 
     def canonicalize_base_url(self, request):
         """Enforces a base_url such as http://localhost:8080 (no path part).
+
+        See :attr:`.Request.host` and :attr:`.Request.scheme` for how the
+        request host and scheme are determined.
         """
         if not self.base_url:
             return
 
-        scheme = self._extract_scheme(request).decode('ascii', 'backslashreplace')
-        host = self._extract_host(request).decode('ascii', 'backslashreplace')
-
-        actual = scheme + "://" + host
+        actual = request.scheme + "://" + request.host
 
         if actual != self.base_url:
             url = self.base_url

--- a/pando/website.py
+++ b/pando/website.py
@@ -229,6 +229,12 @@ class DefaultConfiguration(object):
     colorize_tracebacks = True
     "Use the Pygments package to prettify tracebacks with syntax highlighting."
 
+    known_schemes = {'http', 'https', 'ws', 'wss'}
+    """
+    The set of known and acceptable request URL schemes. Used by
+    :attr:`.Request.scheme`.
+    """
+
     list_directories = False
     "List the contents of directories that don't have a custom index."
 

--- a/pando/website.py
+++ b/pando/website.py
@@ -234,3 +234,26 @@ class DefaultConfiguration(object):
 
     show_tracebacks = False
     "Show Python tracebacks in error responses."
+
+    trusted_proxies = []
+    """
+    The list of reverse proxies that requests to this website go through. With
+    this information we can accurately determine where a request came from (i.e.
+    the IP address of the client) and how it was sent (i.e. encrypted or in
+    plain text).
+
+    Example::
+
+        trusted_proxies=[
+            ['private'],
+            [IPv4Network('1.2.3.4/32'), IPv6Network('2001:2345:6789:abcd::/64')]
+        ]
+
+    Explanation: :attr:`trusted_proxies` is a list of proxy levels, with each
+    item being a list of IP networks (:class:`~ipaddress.IPv4Network` or
+    :class:`~ipaddress.IPv6Network` objects). The special value :obj:`'private'`
+    can be used to indicate that any private IP address is trusted (the
+    :attr:`~ipaddress.IPv4Address.is_private` attribute is used to determine
+    if an IP address is private, both IPv4 and IPv6 are supported).
+
+    """

--- a/requirements.txt
+++ b/requirements.txt
@@ -5,3 +5,4 @@ filesystem_tree>=1.0.1
 dependency_injection>=1.2.0
 aspen==1.0rc7
 six
+ipaddress; python_version < "3.3"


### PR DESCRIPTION
This branch adds four properties to the `Request` class: `.host`, `.scheme`, `.source` and `.bypasses_proxy`. To be able to implement them properly, two new configuration settings are introduced: `known_schemes` and `trusted_proxies`.