### PR TITLE
Prune HTTP header parsing code

### DIFF
--- a/pando/exceptions.py
+++ b/pando/exceptions.py
@@ -23,18 +23,6 @@ class CRLFInjection(Response):
         Response.__init__(self, code=400, body="Possible CRLF Injection detected.")
 
 
-class MalformedHeader(Response):
-    """
-    A 400 :class:`.Response` (per `RFC7230 section 3.2.4`_) raised if there's
-    no ``:`` in a header field, or if there's leading or trailing whitespace in
-    the key part of a header field.
-
-    .. _RFC7230 section 3.2.4: http://tools.ietf.org/html/rfc7230#section-3.2.4
-    """
-    def __init__(self, header):
-        Response.__init__(self, code=400, body="Malformed header: %s" % header)
-
-
 class MalformedBody(Response):
     """
     A 400 :class:`.Response` raised if parsing the body of a POST request fails.

--- a/pando/http/baseheaders.py
+++ b/pando/http/baseheaders.py
@@ -35,27 +35,9 @@ class BaseHeaders(CaseInsensitiveMapping):
     have good notes on why we do everything as pure bytes here.
     """
 
-    def __init__(self, d):
-        """Takes headers as a dict, list, or bytestring.
+    def __init__(self, headers=()):
+        """Takes headers as a dict, or list of items.
         """
-        if isinstance(d, bytes):
-            from pando.exceptions import MalformedHeader
-
-            def genheaders():
-                for line in d.splitlines():
-                    if b':' not in line:
-                        # no colon separator in header
-                        raise MalformedHeader(line)
-                    k, v = line.split(b':', 1)
-                    if k != k.strip():
-                        # disallowed leading or trailing whitspace
-                        # (per http://tools.ietf.org/html/rfc7230#section-3.2.4)
-                        raise MalformedHeader(line)
-                    yield k, v.strip()
-
-            headers = genheaders()
-        else:
-            headers = d
         CaseInsensitiveMapping.__init__(self, headers)
 
         # Cookie

--- a/pando/http/request.py
+++ b/pando/http/request.py
@@ -132,15 +132,13 @@ class Request(object):
     """
 
     def __init__(self, website, method=b'GET', uri=b'/', server_software=b'',
-                version=b'HTTP/1.1', headers=b'', body=None):
+                version=b'HTTP/1.1', headers={b'Host': b'localhost'}, body=None):
         """``body`` is expected to be a file-like object.
         """
         self.website = website
         self.server_software = server_software
         self.body_stream = body
         self.line = Line(method, uri, version)
-        if not headers:
-            headers = b'Host: localhost'
         self.headers = Headers(headers)
 
     @classmethod

--- a/tests/test_mappings.py
+++ b/tests/test_mappings.py
@@ -85,21 +85,21 @@ def test_case_insensitive_mapping_ones_is_case_insensitive():
 
 
 def test_headers_can_be_raw_when_non_ascii():
-    headers = BaseHeaders(b'Foo: b\xc3\xabar\r\nOh: Yeah!')
+    headers = BaseHeaders({b'Foo': b'b\xc3\xabar', b'Oh': b'Yeah!'})
     assert headers.raw == b'Foo: b\xc3\xabar\r\nOh: Yeah!'
 
 def test_headers_reject_CR_injection():
     with raises(CRLFInjection):
-        BaseHeaders(b'')[b'foo'] = b'\rbar'
+        BaseHeaders()[b'foo'] = b'\rbar'
 
 def test_headers_reject_LF_injection():
     with raises(CRLFInjection):
-        BaseHeaders(b'')[b'foo'] = b'\nbar'
+        BaseHeaders()[b'foo'] = b'\nbar'
 
 def test_headers_reject_CR_injection_from_add():
     with raises(CRLFInjection):
-        BaseHeaders(b'').add(b'foo', b'\rbar')
+        BaseHeaders().add(b'foo', b'\rbar')
 
 def test_headers_reject_LF_injection_from_add():
     with raises(CRLFInjection):
-        BaseHeaders(b'').add(b'foo', b'\nbar')
+        BaseHeaders().add(b'foo', b'\nbar')

--- a/tests/test_request.py
+++ b/tests/test_request.py
@@ -10,7 +10,6 @@ from ipaddress import IPv4Network
 from pytest import raises
 
 from pando import Response
-from pando.exceptions import MalformedHeader
 from pando.http.request import kick_against_goad, make_franken_uri, Request
 from pando.http.baseheaders import BaseHeaders
 
@@ -83,38 +82,32 @@ def test_is_xhr_is_case_insensitive(harness):
 
 
 def test_headers_access_gets_a_value():
-    headers = BaseHeaders(b"Foo: Bar")
+    headers = BaseHeaders([(b"Foo", b"Bar")])
     expected = b"Bar"
     actual = headers[b'Foo']
     assert actual == expected
 
 def test_headers_access_gets_last_value():
-    headers = BaseHeaders(b"Foo: Bar\r\nFoo: Baz")
+    headers = BaseHeaders([(b"Foo", b"Bar"), (b"Foo", b"Baz")])
     expected = b"Baz"
     actual = headers[b'Foo']
     assert actual == expected
 
 def test_headers_access_is_case_insensitive():
-    headers = BaseHeaders(b"Foo: Bar")
+    headers = BaseHeaders({b"Foo": b"Bar"})
     expected = b"Bar"
     actual = headers[b'foo']
     assert actual == expected
 
 def test_headers_dont_unicodify_cookie():
-    headers = BaseHeaders(b"Cookie: somecookiedata")
+    headers = BaseHeaders({b"Cookie": b"somecookiedata"})
     expected = b"somecookiedata"
     actual = headers[b'Cookie']
     assert actual == expected
 
 def test_baseheaders_loads_cookies_as_str():
-    headers = BaseHeaders(b"Cookie: key=value")
+    headers = BaseHeaders({b"Cookie": b"key=value"})
     assert headers.cookie[str('key')].value == str('value')
-
-def test_headers_handle_no_colon():
-    raises(MalformedHeader, BaseHeaders, b"Foo Bar")
-
-def test_headers_handle_bad_spaces():
-    raises(MalformedHeader, BaseHeaders, b"Foo : Bar")
 
 
 # aliases


### PR DESCRIPTION
It's a remnant from when Aspen was a web server and parsed HTTP requests directly.